### PR TITLE
Introduce katello::postgresql

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -25,6 +25,10 @@ class katello::application (
   include ::certs::qpid
   include ::katello::qpid_client
 
+  if $::foreman::db_manage {
+    include ::katello::postgresql
+  }
+
   $post_sync_url = "${::foreman::foreman_url}${deployment_url}/api/v2/repositories/sync_complete?token=${post_sync_token}"
   $candlepin_ca_cert = $::certs::ca_cert
   $pulp_ca_cert = $::certs::katello_server_ca_cert

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -16,6 +16,10 @@ class katello::candlepin (
   include ::certs
   include ::certs::candlepin
 
+  if $manage_db {
+    include ::katello::postgresql
+  }
+
   class { '::candlepin':
     user_groups                  => $user_groups,
     oauth_key                    => $oauth_key,

--- a/manifests/postgresql.pp
+++ b/manifests/postgresql.pp
@@ -1,0 +1,18 @@
+class katello::postgresql(
+  Hash[String, Any] $config_entries = {},
+  Hash[String, Hash] $pg_hba_rules = {},
+) {
+  include ::postgresql::server
+
+  $config_entries.each |$entry, $value| {
+    postgresql::server::config_entry { $entry:
+      value => $value,
+    }
+  }
+
+  $pg_hba_rules.each |$rule_name, $rule| {
+    postgresql::server::pg_hba_rule { $rule_name:
+      * => $rule,
+    }
+  }
+}

--- a/spec/classes/katello_postgresql_spec.rb
+++ b/spec/classes/katello_postgresql_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'katello::postgresql' do
+  on_os_under_test.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('postgresql::server') }
+      end
+
+      context 'with config entries and hba rules' do
+        let :params do
+          {
+            :config_entries => {
+              'log_min_duration_statement' => 2000,
+              'max_connections'            => 42,
+            },
+            :pg_hba_rules => {
+              'local admin' => {
+                'type'        => 'local',
+                'database'    => 'all',
+                'user'        => 'admin',
+                'order'       => 1,
+                'auth_method' => 'trust',
+              },
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('postgresql::server') }
+        it { is_expected.to contain_postgresql__server__config_entry('log_min_duration_statement').with_value(2000) }
+        it { is_expected.to contain_postgresql__server__config_entry('max_connections').with_value(42) }
+
+        it do
+          is_expected.to contain_postgresql__server__pg_hba_rule('local admin'). \
+            with_type('local'). \
+            with_database('all'). \
+            with_user('admin'). \
+            with_order(1). \
+            with_auth_method('trust')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently it's impossible to tune postgresql from the installer. This patch allows setting tuning parameters through hiera while making no difference to the current installation.

In the future this class could be exposed as a top level manage flag so you can set up split deployments.