### PR TITLE
pulp: manage_httpd

### DIFF
--- a/files/pub-apache.conf
+++ b/files/pub-apache.conf
@@ -1,10 +1,10 @@
 ### File managed with puppet ###
 
-Include /etc/pulp/vhosts80/*.conf
-
-<Location /pulp>
+Alias /pub /var/www/html/pub
+<Location /pub>
   <IfModule mod_passenger.c>
     PassengerEnabled off
   </IfModule>
   Options +FollowSymLinks +Indexes
+  Require all granted
 </Location>

--- a/files/pulp-apache-ssl.conf
+++ b/files/pulp-apache-ssl.conf
@@ -3,11 +3,3 @@
 <Location /pulp/api>
   SSLUsername SSL_CLIENT_S_DN_CN
 </Location>
-
-Alias /pub /var/www/html/pub
-<Location /pub>
-  <IfModule mod_passenger.c>
-    PassengerEnabled off
-  </IfModule>
-  Options +FollowSymLinks +Indexes
-</Location>


### PR DESCRIPTION
This introduces a parameter `manage_httpd` that is required for setups where pulp should live on a standalone host.
This parameter is not exposed in init.pp on purpose for now. Users that want to use this can do something like this or use Hiera:

```puppet
class { '::katello':
  manage_candlepin   => false,
  manage_qpid        => false,
  manage_pulp        => false, # explicitly declared below to overwrite parameters
  manage_application => false,
  qpid_hostname      => 'qpid.example.com',
  proxy_url          => 'http://proxy.example.com',
  proxy_port         => 8000,
}

class { '::katello::pulp':
  manage_httpd => true,
}
```

This also removes one duplicate of the pubdir declaration.