### PR TITLE
Fixes #22907 - expose Pulp DB configuration params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -89,6 +89,40 @@
 #                        mongo database has slow I/O, then setting a higher number may resolve issues where workers are
 #                        going missing incorrectly.
 #
+# $pulp_db_name::        Name of the database to use
+#
+# $pulp_db_seeds::       Comma-separated list of hostname:port of database replica seed hosts
+#
+# $pulp_db_username::    The user name to use for authenticating to the MongoDB server
+#
+# $pulp_db_password::    The password to use for authenticating to the MongoDB server
+#
+# $pulp_db_replica_set:: The name of replica set configured in MongoDB, if one is in use
+#
+# $pulp_db_ssl::         Whether to connect to the database server using SSL.
+#
+# $pulp_db_ssl_keyfile:: A path to the private keyfile used to identify the local connection against mongod. If
+#                        included with the certfile then only the ssl_certfile is needed.
+#
+# $pulp_db_ssl_certfile:: The certificate file used to identify the local connection against mongod.
+#
+# $pulp_db_verify_ssl::  Specifies whether a certificate is required from the other side of the connection, and
+#                        whether it will be validated if provided. If it is true, then the ca_certs parameter
+#                        must point to a file of CA certificates used to validate the connection.
+#
+# $pulp_db_ca_path::     The ca_certs file contains a set of concatenated "certification authority" certificates,
+#                        which are used to validate certificates passed from the other end of the connection.
+#
+# $pulp_db_unsafe_autoretry:: If true, retry commands to the database if there is a connection error.
+#                             Warning: if set to true, this setting can result in duplicate records.
+#
+# $pulp_db_write_concern:: Write concern of 'majority' or 'all'. When 'all' is specified, 'w' is set to number of
+#                          seeds specified. For version of MongoDB < 2.6, replica_set must also be specified.
+#                          Please note that 'all' will cause Pulp to halt if any of the replica set members is not
+#                          available. 'majority' is used by default
+#
+# $pulp_manage_db::      Boolean to install and configure the mongodb.
+#
 class katello (
   String $user = $::katello::params::user,
   String $group = $::katello::params::group,
@@ -136,6 +170,20 @@ class katello (
   Boolean $candlepin_db_ssl = $::katello::params::candlepin_db_ssl,
   Boolean $candlepin_db_ssl_verify = $::katello::params::candlepin_db_ssl_verify,
   Boolean $candlepin_manage_db = $::katello::params::candlepin_manage_db,
+
+  String $pulp_db_name = $::katello::params::pulp_db_name,
+  String $pulp_db_seeds = $::katello::params::pulp_db_seeds,
+  Optional[String] $pulp_db_username = $::katello::params::pulp_db_username,
+  Optional[String] $pulp_db_password = $::katello::params::pulp_db_password,
+  Optional[String] $pulp_db_replica_set = $::katello::params::pulp_db_replica_set,
+  Boolean $pulp_db_ssl = $::katello::params::pulp_db_ssl,
+  Optional[Stdlib::Absolutepath] $pulp_db_ssl_keyfile = $::katello::params::pulp_db_ssl_keyfile,
+  Optional[Stdlib::Absolutepath] $pulp_db_ssl_certfile = $::katello::params::pulp_db_ssl_certfile,
+  Boolean $pulp_db_verify_ssl = $::katello::params::pulp_db_verify_ssl,
+  Stdlib::Absolutepath $pulp_db_ca_path = $::katello::params::pulp_db_ca_path,
+  Boolean $pulp_db_unsafe_autoretry = $::katello::params::pulp_db_unsafe_autoretry,
+  Optional[Enum['majority', 'all']] $pulp_db_write_concern = $::katello::params::pulp_db_write_concern,
+  Boolean $pulp_manage_db = $::katello::params::pulp_manage_db,
 ) inherits katello::params {
   include ::katello::repo
   include ::katello::candlepin

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -93,4 +93,19 @@ class katello::params {
   $candlepin_db_ssl = false
   $candlepin_db_ssl_verify = true
   $candlepin_manage_db = true
+
+  # pulp database settings
+  $pulp_manage_db = true
+  $pulp_db_name = 'pulp_database'
+  $pulp_db_seeds = 'localhost:27017'
+  $pulp_db_username = undef
+  $pulp_db_password = undef
+  $pulp_db_replica_set = undef
+  $pulp_db_ssl = false
+  $pulp_db_ssl_keyfile = undef
+  $pulp_db_ssl_certfile = undef
+  $pulp_db_verify_ssl = true
+  $pulp_db_ca_path = '/etc/pki/tls/certs/ca-bundle.crt'
+  $pulp_db_unsafe_autoretry = false
+  $pulp_db_write_concern = undef
 }

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -19,6 +19,19 @@ class katello::pulp (
   String $repo_export_dir_owner = $::katello::user,
   String $repo_export_dir_group = $::katello::group,
   Integer[0] $pulp_worker_timeout = $::katello::pulp_worker_timeout,
+  String $db_name = $::katello::pulp_db_name,
+  String $db_seeds = $::katello::pulp_db_seeds,
+  Optional[String] $db_username = $::katello::pulp_db_username,
+  Optional[String] $db_password = $::katello::pulp_db_password,
+  Optional[String] $db_replica_set = $::katello::pulp_db_replica_set,
+  Boolean $db_ssl = $::katello::pulp_db_ssl,
+  Optional[Stdlib::Absolutepath] $db_ssl_keyfile = $::katello::pulp_db_ssl_keyfile,
+  Optional[Stdlib::Absolutepath] $db_ssl_certfile = $::katello::pulp_db_ssl_certfile,
+  Boolean $db_verify_ssl = $::katello::pulp_db_verify_ssl,
+  Stdlib::Absolutepath $db_ca_path = $::katello::pulp_db_ca_path,
+  Boolean $db_unsafe_autoretry = $::katello::pulp_db_unsafe_autoretry,
+  Optional[Enum['majority', 'all']] $db_write_concern = $::katello::pulp_db_write_concern,
+  Boolean $manage_db = $::katello::pulp_manage_db,
 ) {
   include ::certs
   include ::certs::qpid_client
@@ -54,6 +67,19 @@ class katello::pulp (
     enable_katello         => true,
     subscribe              => Class['certs', 'certs::qpid_client'],
     worker_timeout         => $pulp_worker_timeout,
+    db_name                => $db_name,
+    db_seeds               => $db_seeds,
+    db_username            => $db_username,
+    db_password            => $db_password,
+    db_replica_set         => $db_replica_set,
+    db_ssl                 => $db_ssl,
+    db_ssl_keyfile         => $db_ssl_keyfile,
+    db_ssl_certfile        => $db_ssl_certfile,
+    db_verify_ssl          => $db_verify_ssl,
+    db_ca_path             => $db_ca_path,
+    db_unsafe_autoretry    => $db_unsafe_autoretry,
+    db_write_concern       => $db_write_concern,
+    manage_db              => $manage_db,
   }
 
   contain ::pulp

--- a/spec/classes/katello_pulp_spec.rb
+++ b/spec/classes/katello_pulp_spec.rb
@@ -49,6 +49,10 @@ describe 'katello::pulp' do
             .with_repo_auth(true)
             .with_puppet_wsgi_processes(1)
             .with_enable_katello(true)
+            .with_manage_db(true)
+            .with_db_name('pulp_database')
+            .with_db_seeds('localhost:27017')
+            .with_db_ssl(false)
             .that_subscribes_to('Class[Certs::Qpid_client]')
         end
 
@@ -66,6 +70,27 @@ describe 'katello::pulp' do
             .with_owner('foreman')
             .with_group('foreman')
             .with_mode('0755')
+        end
+      end
+
+      context 'with explicit parameters' do
+        let :pre_condition do
+          <<-EOS
+          class { '::katello':
+            pulp_db_name      => 'pulp_db',
+            pulp_db_username  => 'pulp_user',
+            pulp_db_password  => 'pulp_pw',
+            pulp_db_seeds     => '192.168.1.1:27017'
+          }
+          EOS
+        end
+
+        it do
+          is_expected.to create_class('pulp')
+            .with_db_name('pulp_db')
+            .with_db_username('pulp_user')
+            .with_db_password('pulp_pw')
+            .with_db_seeds('192.168.1.1:27017')
         end
       end
     end


### PR DESCRIPTION
This patch exposes most of the Pulp DB configuration and visible from installer.
The params are listed as advanced and not pollute installer --help.
I was able to install Katello with remote mongo with:
```
foreman-installer \
  --scenario katello \
  --katello-pulp-db-username=pulp_user \
  --katello-pulp-db-password=pulp \
  --katello-pulp-db-seeds="192.168.121.43:27017" \
  --katello-pulp-db-name="pulp_database" \
  --foreman-admin-password=changeme
```