### PR TITLE
Fixes #23624 - make Apache directory options for /pub configurable

### DIFF
--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -32,6 +32,7 @@ class katello::pulp (
   Boolean $db_unsafe_autoretry = $::katello::pulp_db_unsafe_autoretry,
   Optional[Enum['majority', 'all']] $db_write_concern = $::katello::pulp_db_write_concern,
   Boolean $manage_db = $::katello::pulp_manage_db,
+  String $pub_dir_options = '+FollowSymLinks +Indexes',
 ) {
   include ::certs
   include ::certs::qpid_client
@@ -85,8 +86,8 @@ class katello::pulp (
   contain ::pulp
 
   foreman::config::passenger::fragment { 'pulp':
-    content     => file('katello/pulp-apache.conf'),
-    ssl_content => file('katello/pulp-apache-ssl.conf'),
+    content     => template('katello/pulp-apache.conf.erb'),
+    ssl_content => template('katello/pulp-apache-ssl.conf.erb'),
   }
 
   # NB: we define this here to avoid a dependency cycle. It is not a problem if

--- a/templates/pulp-apache-ssl.conf.erb
+++ b/templates/pulp-apache-ssl.conf.erb
@@ -9,5 +9,5 @@ Alias /pub /var/www/html/pub
   <IfModule mod_passenger.c>
     PassengerEnabled off
   </IfModule>
-  Options +FollowSymLinks +Indexes
+  Options <%= @pub_dir_options %>
 </Location>

--- a/templates/pulp-apache.conf.erb
+++ b/templates/pulp-apache.conf.erb
@@ -6,7 +6,7 @@ Alias /pub /var/www/html/pub
   <IfModule mod_passenger.c>
     PassengerEnabled off
   </IfModule>
-  Options +FollowSymLinks +Indexes
+  Options <%= @pub_dir_options %>
   Require all granted
 </Location>
 


### PR DESCRIPTION
Hi,

These changes make the Apache directory options for /pub configurable via custom-hiera.yaml.
This is helpful when you need to disable directory listing for security scanner compliance.
By default nothing is changed, but if directory listing of /pub (both HTTP and HTTPS) were desired, adding the following line to `/etc/foreman-installer/custom-hiera.yaml` would prevent autoindex:
~~~
katello::pulp::pub_dir_options: "+FollowSymLinks"
~~~
Thank you in advance, and special thanks to @beav for all the help!