### PR TITLE
Refer to the correct $nss_db_ variable

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -12,7 +12,7 @@ class katello::qpid (
 
   class { '::qpid':
     ssl                    => true,
-    ssl_cert_db            => $::certs::nss_db_dir,
+    ssl_cert_db            => $::certs::qpid::nss_db_dir,
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     ssl_cert_name          => 'broker',
     interface              => $interface,

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -8,7 +8,7 @@ class katello::qpid_client {
   class { '::qpid::client':
     ssl                    => true,
     ssl_cert_name          => 'broker',
-    ssl_cert_db            => $::certs::nss_db_dir,
+    ssl_cert_db            => $::certs::qpid::nss_db_dir,
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     require                => Class['certs', 'certs::qpid'],
   }


### PR DESCRIPTION
While it's also available at the certs top scope, it's not the most accurate place. This also points out we really only use the certs::qpid and certs is more an internal detail. We should probably look at only including certs::qpid which is probably enough due to the inhertince but that's for later.