### PR TITLE
Allow puppetlabs/stdlib => 4.25.1

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.6.0 < 6.0.0"
+      "version_requirement": ">= 4.25.1 < 6.0.0"
     },
     {
       "name": "katello-candlepin",


### PR DESCRIPTION
puppetlabs/stdlib 4.6.0 is a non-existent version. This change was introduced in https://github.com/theforeman/puppet-katello/commit/898eae48d45b0a3785c1dbabce1d35ca3f7c02be and subsequently the rest of the commit removed in https://github.com/theforeman/puppet-katello/commit/5de2e01795aac52e84cd88dc5d57b0841de8657e. This change is to roll back the minimum required version of stdlib to 4.25.1. I have ran a test against that here: https://travis-ci.org/SeanHood/puppet-katello/jobs/444994576. `.fixtures.yml` needed to be changed to allow for this, hence missing from this commit.

The reason behind this change is that a handful of modules still have a requirement on < 5.0.0. This module doesn't use any of the newly introduced functions in that release.