### PR TITLE
Simplify package name handling

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,25 +1,12 @@
 # Katello Default Params
 class katello::params {
 
-  case $::osfamily {
-    'RedHat': {
-      case $::operatingsystem {
-        'Fedora': {
-          $rubygem_katello = 'rubygem-katello'
-          $rubygem_katello_ostree ='rubygem-katello_ostree'
-        }
-        default: {
-          $rubygem_katello = 'tfm-rubygem-katello'
-          $rubygem_katello_ostree ='tfm-rubygem-katello_ostree'
-        }
-      }
-
-      $package_names = ['katello', $rubygem_katello]
-    }
-    default: {
-      fail("${::hostname}: This module does not support osfamily ${::osfamily}")
-    }
+  if $::operatingsystem == 'Fedora' {
+    $rubygem_katello = 'rubygem-katello'
+  } else {
+    $rubygem_katello = 'tfm-rubygem-katello'
   }
+  $package_names = ['katello', $rubygem_katello]
 
   $deployment_url = '/katello'
 

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -16,20 +16,4 @@ describe 'katello' do
       it { is_expected.to contain_package('katello').that_requires('Class[candlepin]') }
     end
   end
-
-  context 'on unsupported osfamily' do
-    let :facts do
-      {
-        :concat_basedir            => '/tmp',
-        :hostname                  => 'localhost',
-        :operatingsystem           => 'UNSUPPORTED OPERATINGSYSTEM',
-        :operatingsystemmajrelease => '1',
-        :operatingsystemrelease    => '1',
-        :osfamily                  => 'UNSUPPORTED OSFAMILY',
-        :root_home                 => '/root'
-      }
-    end
-
-    it { expect { should contain_class('katello') }.to raise_error(Puppet::Error, /#{facts[:hostname]}: This module does not support osfamily #{facts[:osfamily]}/) }
-  end
 end


### PR DESCRIPTION
f614db22fdb78f67b2e778f1729512683de4a251 removed the use of $rubygem_katello_ostree variable, but not its definition.

We also don't want to hard fail because we sometimes want to compile on other distros. The most common use case is CI testing our installer by running it with --help. Since that happens on Travis (which is Ubuntu) it hard fails.