### PR TITLE
Fixes #25966 - order all candlepin actions after qpid

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -193,6 +193,6 @@ class katello (
   Class['katello::repo'] -> Class['katello::pulp']
   include katello::application
   Class['katello::repo'] -> Class['katello::application']
-  Class['katello::candlepin'] -> Class['katello::application']
+  Class['katello::qpid'] -> Class['katello::candlepin'] -> Class['katello::application']
 
 }

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -14,6 +14,8 @@ describe 'katello' do
       it { is_expected.to contain_class('katello::qpid') }
 
       it { is_expected.to contain_package('katello').that_requires('Class[candlepin]') }
+
+      it { is_expected.to contain_service('tomcat').that_requires('Qpid::Config::Bind[entitlement.created]') }
     end
   end
 end


### PR DESCRIPTION
this is required for Candlepin 2.5.10, see [1] for details

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1570534