### PR TITLE
[CP] Refs #26571 - Add Qpid ACL file

### DIFF
--- a/files/qpid_acls.acl
+++ b/files/qpid_acls.acl
@@ -1,0 +1,14 @@
+# allow the actions needed by katello_agent
+acl allow katello_agent@QPID create queue
+acl allow katello_agent@QPID consume queue
+acl allow katello_agent@QPID access exchange
+acl allow katello_agent@QPID access queue
+acl allow katello_agent@QPID publish exchange routingkey=pulp.task
+acl allow katello_agent@QPID publish exchange name=qmf.default.direct
+acl allow katello_agent@QPID access method name=create
+
+acl deny-log katello_agent@QPID access method name=*
+acl deny-log katello_agent@QPID all all
+
+# allow anything else
+acl allow all all

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -15,6 +15,7 @@ class katello::qpid (
     ssl_cert_db            => $::certs::qpid::nss_db_dir,
     ssl_cert_password_file => $::certs::qpid::nss_db_password_file,
     ssl_cert_name          => 'broker',
+    acl_content            => file('katello/qpid_acls.acl'),
     interface              => $interface,
     wcache_page_size       => $wcache_page_size,
     subscribe              => Class['certs', 'certs::qpid'],

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "katello-qpid",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 4.3.2 < 5.0.0"
     },
     {
       "name": "theforeman-foreman",


### PR DESCRIPTION
(cherry picked from commit fb3804643925b5177d7443f112641b29c5d74155)

@ekohl here's the pick for 3.10.1

- puppet-qpid: https://github.com/theforeman/puppet-qpid/pull/123
- I think puppet-foreman_proxy_content needs a 7.3-stable branch for me to pick on to, but I have a branch prepared locally