### PR TITLE
Allow management of single products and add manage_httpd parameter for pulp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,11 +192,14 @@ class katello (
 ) inherits katello::params {
 
   include katello::repo
-  if $manage_candlepin {
-    include katello::candlepin
-  }
   if $manage_qpid {
     include katello::qpid
+  }
+  if $manage_candlepin {
+    include katello::candlepin
+    if $manage_qpid {
+      Class['katello::qpid'] -> Class['katello::candlepin']
+    }
   }
   if $manage_pulp {
     include katello::pulp
@@ -205,8 +208,8 @@ class katello (
   if $manage_application {
     include katello::application
     Class['katello::repo'] -> Class['katello::application']
-    if $manage_qpid and $manage_candlepin {
-      Class['katello::qpid'] -> Class['katello::candlepin'] -> Class['katello::application']
+    if $manage_candlepin {
+      Class['katello::candlepin'] -> Class['katello::application']
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -62,6 +62,11 @@ class katello::params {
   $enable_docker = true
   $enable_deb = true
 
+  $manage_application = true
+  $manage_qpid = true
+  $manage_pulp = true
+  $manage_candlepin = true
+
   $manage_repo = false
   $repo_version = 'latest'
   $repo_yumcode = "el${facts['operatingsystemmajrelease']}"

--- a/spec/classes/katello_pulp_spec.rb
+++ b/spec/classes/katello_pulp_spec.rb
@@ -87,6 +87,27 @@ describe 'katello::pulp' do
             .with_db_password('pulp_pw')
             .with_db_seeds('192.168.1.1:27017')
         end
+
+        context 'with manage_httpd => true' do
+          let :pre_condition do
+            <<-EOS
+            class { '::katello':
+              manage_application => false,
+              manage_qpid => false,
+              manage_candlepin => false,
+              manage_pulp => false,
+            }
+            class { '::katello::pulp':
+              manage_httpd => true,
+            }
+            EOS
+          end
+
+          it do
+            is_expected.to create_class('pulp')
+              .with_manage_httpd(true)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds the feature to only manage some parts of the installation (Katello, Pulp, Candlepin, Qpid) which is needed for a distributed setup.
It also introduces the `manage_httpd` parameter to `::katello::pulp` to enable the management of Apache for a standalone Pulp installation.

The `http_manage` parameter is not exposed in the `init.pp` for now. For that reason it is necessary to call the module as follows if one want's to use the parameter:
```
class { '::katello':
  manage_candlepin   => false,
  manage_qpid        => false,
  manage_pulp        => false, # explicitly declared below to overwrite parameters
  manage_application => false,
  qpid_hostname      => 'qpid.example.com',
  proxy_url          => 'http://proxy.example.com',
  proxy_port         => 8000,
}

class { '::katello::pulp':
  manage_httpd => true,
}
```

The originating PR is https://github.com/theforeman/puppet-katello/pull/218