### PR TITLE
Use the nss cert name from certs::qpid

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -18,7 +18,7 @@ class katello::qpid (
     ssl                    => true,
     ssl_cert_db            => $certs::qpid::nss_db_dir,
     ssl_cert_password_file => $certs::qpid::nss_db_password_file,
-    ssl_cert_name          => 'broker',
+    ssl_cert_name          => $certs::qpid::nss_cert_name,
     acl_content            => file('katello/qpid_acls.acl'),
     interface              => $interface,
     wcache_page_size       => $wcache_page_size,

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -9,7 +9,7 @@ class katello::qpid_client {
 
   class { 'qpid::client':
     ssl                    => true,
-    ssl_cert_name          => 'broker',
+    ssl_cert_name          => $certs::qpid::nss_cert_name,
     ssl_cert_db            => $certs::qpid::nss_db_dir,
     ssl_cert_password_file => $certs::qpid::nss_db_password_file,
     require                => Class['certs', 'certs::qpid'],

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "katello/pulp",


### PR DESCRIPTION
Rather than hardcoding it, the certs class that actually creates these should be responsible for naming it.

Draft because it depends on https://github.com/theforeman/puppet-certs/pull/265