### PR TITLE
Implement automatic dependency chaining

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -52,7 +52,7 @@ class katello::application (
   Class['certs', 'certs::ca', 'certs::qpid'] ~> Class['foreman::plugin::tasks']
 
   # Katello database seeding needs candlepin
-  Anchor <| title == 'katello::repo' |> ->
+  Anchor <| title == 'katello::repo' or title ==  'katello::candlepin' |> ->
   package { $package_names:
     ensure => installed,
   } ->

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -52,6 +52,7 @@ class katello::application (
   Class['certs', 'certs::ca', 'certs::qpid'] ~> Class['foreman::plugin::tasks']
 
   # Katello database seeding needs candlepin
+  Anchor <| title == 'katello::repo' |> ->
   package { $package_names:
     ensure => installed,
   } ->

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -46,7 +46,8 @@ class katello::candlepin (
     db_ssl_verify                => $db_ssl_verify,
     manage_db                    => $manage_db,
     subscribe                    => Class['certs', 'certs::candlepin'],
-  }
+  } ->
+  anchor { 'katello::candlepin': }
 
   contain candlepin
 }

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -16,6 +16,7 @@ class katello::candlepin (
   include certs
   include certs::candlepin
 
+  Anchor <| title == 'katello::qpid::event_queue' |> ->
   class { 'candlepin':
     user_groups                  => $user_groups,
     oauth_key                    => $oauth_key,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,6 +169,6 @@ class katello (
   include katello::qpid
   include katello::pulp
   include katello::application
-  Class['katello::qpid'] -> Class['katello::candlepin'] -> Class['katello::application']
+  Class['katello::candlepin'] -> Class['katello::application']
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -169,6 +169,5 @@ class katello (
   include katello::qpid
   include katello::pulp
   include katello::application
-  Class['katello::candlepin'] -> Class['katello::application']
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,15 +52,6 @@
 #
 # $package_names::      Packages that this module ensures are present instead of the default
 #
-# $manage_repo::        Whether to manage the yum repository
-#
-# $repo_version::       Which yum repository to install. For example
-#                       latest or 3.3.
-#
-# $repo_gpgcheck::      Whether to check the GPG signatures
-#
-# $repo_gpgkey::        The GPG key to use
-#
 # $candlepin_db_host::  Host with Candlepin DB
 #
 # $candlepin_db_port::  Port accepting connections to Candlepin DB
@@ -150,11 +141,6 @@ class katello (
 
   Stdlib::Absolutepath $repo_export_dir = $katello::params::repo_export_dir,
 
-  Boolean $manage_repo = $katello::params::manage_repo,
-  String $repo_version = $katello::params::repo_version,
-  Boolean $repo_gpgcheck = $katello::params::repo_gpgcheck,
-  Optional[String] $repo_gpgkey = $katello::params::repo_gpgkey,
-
   String $candlepin_db_host = $katello::params::candlepin_db_host,
   Optional[Integer[0, 65535]] $candlepin_db_port = $katello::params::candlepin_db_port,
   String $candlepin_db_name = $katello::params::candlepin_db_name,
@@ -179,13 +165,10 @@ class katello (
   Boolean $pulp_manage_db = $katello::params::pulp_manage_db,
 ) inherits katello::params {
 
-  include katello::repo
   include katello::candlepin
   include katello::qpid
   include katello::pulp
-  Class['katello::repo'] -> Class['katello::pulp']
   include katello::application
-  Class['katello::repo'] -> Class['katello::application']
   Class['katello::qpid'] -> Class['katello::candlepin'] -> Class['katello::application']
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,12 +59,6 @@ class katello::params {
   $enable_docker = true
   $enable_deb = true
 
-  $manage_repo = false
-  $repo_version = 'latest'
-  $repo_yumcode = "el${facts['operatingsystemmajrelease']}"
-  $repo_gpgcheck = false
-  $repo_gpgkey = undef
-
   # candlepin database settings
   $candlepin_db_host = 'localhost'
   $candlepin_db_port = undef

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -1,12 +1,12 @@
 # Katello configuration for pulp
 class katello::pulp (
   Optional[String] $yum_max_speed = $katello::pulp_max_speed,
-  Boolean $enable_ostree = $katello::enable_ostree,
-  Boolean $enable_yum = $katello::enable_yum,
-  Boolean $enable_file = $katello::enable_file,
-  Boolean $enable_puppet = $katello::enable_puppet,
-  Boolean $enable_docker = $katello::enable_docker,
-  Boolean $enable_deb = $katello::enable_deb,
+  Optional[Boolean] $enable_ostree = $katello::enable_ostree,
+  Optional[Boolean] $enable_yum = $katello::enable_yum,
+  Optional[Boolean] $enable_file = $katello::enable_file,
+  Optional[Boolean] $enable_puppet = $katello::enable_puppet,
+  Optional[Boolean] $enable_docker = $katello::enable_docker,
+  Optional[Boolean] $enable_deb = $katello::enable_deb,
   Integer[1] $num_workers = $katello::num_pulp_workers,
   String $messaging_url = "ssl://${katello::qpid_hostname}:5671",
   String $broker_url = "qpid://${katello::qpid_hostname}:5671",
@@ -41,6 +41,7 @@ class katello::pulp (
     ssl_content => template('katello/pulp-apache-ssl.conf.erb'),
   }
 
+  Anchor <| title == 'katello::repo' |> ->
   class { 'pulp':
     server_name            => $server_name,
     messaging_url          => $messaging_url,

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -37,5 +37,7 @@ class katello::qpid (
     ssl_cert => $certs::qpid::client_cert,
     ssl_key  => $certs::qpid::client_key,
     hostname => $hostname,
-  }
+  } ->
+  # This anchor indicates the event queue is all set up.
+  anchor { 'katello::qpid::event_queue': }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,17 +1,25 @@
+# @summary Manage the Katello repository
+#
+# @param repo_version
+#   The repository version to use. Either latest or a version like 3.14.
+# @param dist
+#   The distribution to use
+# @param gpgcheck
+#   Whether GPG signatures need to be checked
+# @param gpgkey
+#   The location of the GPG key
 class katello::repo (
-  Boolean $manage_repo = $katello::manage_repo,
-  String $repo_version = $katello::repo_version,
-  String $dist = $katello::repo_yumcode,
-  Boolean $gpgcheck = $katello::repo_gpgcheck,
-  Optional[String] $gpgkey = $katello::repo_gpgkey,
+  String $repo_version = latest,
+  String $dist = "el${facts['operatingsystemmajrelease']}",
+  Boolean $gpgcheck = false,
+  String $gpgkey = 'absent',
 ) {
-  if $manage_repo {
-    yumrepo { 'katello':
-      descr    => "katello ${repo_version}",
-      baseurl  => "https://fedorapeople.org/groups/katello/releases/yum/${repo_version}/katello/${dist}/\$basearch/",
-      gpgkey   => $gpgkey,
-      gpgcheck => $gpgcheck,
-      enabled  => true,
-    }
+  yumrepo { 'katello':
+    descr    => "katello ${repo_version}",
+    baseurl  => "https://fedorapeople.org/groups/katello/releases/yum/${repo_version}/katello/${dist}/\$basearch/",
+    gpgkey   => $gpgkey,
+    gpgcheck => $gpgcheck,
+    enabled  => true,
   }
+  -> anchor { 'katello::repo': }
 }

--- a/spec/classes/katello_application_spec.rb
+++ b/spec/classes/katello_application_spec.rb
@@ -36,6 +36,7 @@ describe 'katello::application' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_package('tfm-rubygem-katello') }
+          it { is_expected.not_to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
           it { is_expected.to contain_class('certs::qpid') }
           it { is_expected.to contain_class('katello::qpid_client') }
 
@@ -245,7 +246,7 @@ describe 'katello::application' do
         end
 
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_package('tfm-rubygem-katello') }
+        it { is_expected.to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
         it { is_expected.to create_package('katello') }
         it do
           is_expected.to contain_package('tfm-rubygem-katello')

--- a/spec/classes/katello_application_spec.rb
+++ b/spec/classes/katello_application_spec.rb
@@ -99,6 +99,13 @@ describe 'katello::application' do
               '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
             ])
           end
+
+          context 'with repo present' do
+            let(:pre_condition) { 'include katello::repo' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_package('tfm-rubygem-katello').that_requires(['Anchor[katello::repo]', 'Yumrepo[katello]']) }
+          end
         end
 
         context 'with enable_ostree => true' do

--- a/spec/classes/katello_candlepin_spec.rb
+++ b/spec/classes/katello_candlepin_spec.rb
@@ -26,6 +26,7 @@ describe 'katello::candlepin' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
         it { is_expected.to contain_class('candlepin') }
+        it { is_expected.not_to contain_class('candlepin').that_requires('Anchor[katello::qpid::event_queue]') }
       end
 
       context 'with inherited parameters' do
@@ -35,7 +36,7 @@ describe 'katello::candlepin' do
 
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('candlepin') }
+        it { is_expected.to contain_class('candlepin').that_requires('Anchor[katello::qpid::event_queue]') }
       end
     end
   end

--- a/spec/classes/katello_pulp_spec.rb
+++ b/spec/classes/katello_pulp_spec.rb
@@ -8,84 +8,86 @@ describe 'katello::pulp' do
       end
 
       context 'with inherited parameters' do
-        let :pre_condition do
-          <<-EOS
-          class { '::katello':
-            num_pulp_workers  => 1,
-          }
-          EOS
+        context 'minimal set' do
+          let :pre_condition do
+            <<-EOS
+            class { '::katello':
+              num_pulp_workers  => 1,
+            }
+            EOS
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('certs') }
+          it { is_expected.to contain_class('certs::qpid_client') }
+
+          it do
+            is_expected.to create_class('pulp')
+              .with_messaging_url('ssl://localhost:5671')
+              .with_messaging_ca_cert('/etc/pki/pulp/qpid/ca.crt')
+              .with_messaging_client_cert('/etc/pki/pulp/qpid/client.crt')
+              .with_messaging_transport('qpid')
+              .with_messaging_auth_enabled(false)
+              .with_broker_url('qpid://localhost:5671')
+              .with_broker_use_ssl(true)
+              .with_yum_max_speed(nil)
+              .with_manage_broker(false)
+              .with_manage_httpd(false)
+              .with_manage_plugins_httpd(true)
+              .with_manage_squid(true)
+              .with_enable_rpm(true)
+              .with_enable_iso(true)
+              .with_enable_puppet(true)
+              .with_enable_docker(true)
+              .with_enable_ostree(false)
+              .with_num_workers(1)
+              .with_enable_parent_node(false)
+              .with_repo_auth(true)
+              .with_puppet_wsgi_processes(1)
+              .with_enable_katello(true)
+              .with_manage_db(true)
+              .with_db_name('pulp_database')
+              .with_db_seeds('localhost:27017')
+              .with_db_ssl(false)
+              .that_subscribes_to('Class[Certs::Qpid_client]')
+          end
+
+          it do
+            is_expected.to create_foreman__config__apache__fragment('pulp')
+              .with_content(%r{^<Location /pulp>$})
+              .with_ssl_content(%r{^<Location /pulp/api>$})
+          end
+
+          it { is_expected.to create_file('/var/lib/pulp') }
+
+          it do
+            is_expected.to create_file('/var/lib/pulp/katello-export')
+              .with_ensure('directory')
+              .with_owner('foreman')
+              .with_group('foreman')
+              .with_mode('0755')
+          end
         end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('certs') }
-        it { is_expected.to contain_class('certs::qpid_client') }
+        context 'database parameters' do
+          let :pre_condition do
+            <<-EOS
+            class { '::katello':
+              pulp_db_name      => 'pulp_db',
+              pulp_db_username  => 'pulp_user',
+              pulp_db_password  => 'pulp_pw',
+              pulp_db_seeds     => '192.168.1.1:27017'
+            }
+            EOS
+          end
 
-        it do
-          is_expected.to create_class('pulp')
-            .with_messaging_url('ssl://localhost:5671')
-            .with_messaging_ca_cert('/etc/pki/pulp/qpid/ca.crt')
-            .with_messaging_client_cert('/etc/pki/pulp/qpid/client.crt')
-            .with_messaging_transport('qpid')
-            .with_messaging_auth_enabled(false)
-            .with_broker_url('qpid://localhost:5671')
-            .with_broker_use_ssl(true)
-            .with_yum_max_speed(nil)
-            .with_manage_broker(false)
-            .with_manage_httpd(false)
-            .with_manage_plugins_httpd(true)
-            .with_manage_squid(true)
-            .with_enable_rpm(true)
-            .with_enable_iso(true)
-            .with_enable_puppet(true)
-            .with_enable_docker(true)
-            .with_enable_ostree(false)
-            .with_num_workers(1)
-            .with_enable_parent_node(false)
-            .with_repo_auth(true)
-            .with_puppet_wsgi_processes(1)
-            .with_enable_katello(true)
-            .with_manage_db(true)
-            .with_db_name('pulp_database')
-            .with_db_seeds('localhost:27017')
-            .with_db_ssl(false)
-            .that_subscribes_to('Class[Certs::Qpid_client]')
-        end
-
-        it do
-          is_expected.to create_foreman__config__apache__fragment('pulp')
-            .with_content(%r{^<Location /pulp>$})
-            .with_ssl_content(%r{^<Location /pulp/api>$})
-        end
-
-        it { is_expected.to create_file('/var/lib/pulp') }
-
-        it do
-          is_expected.to create_file('/var/lib/pulp/katello-export')
-            .with_ensure('directory')
-            .with_owner('foreman')
-            .with_group('foreman')
-            .with_mode('0755')
-        end
-      end
-
-      context 'with explicit parameters' do
-        let :pre_condition do
-          <<-EOS
-          class { '::katello':
-            pulp_db_name      => 'pulp_db',
-            pulp_db_username  => 'pulp_user',
-            pulp_db_password  => 'pulp_pw',
-            pulp_db_seeds     => '192.168.1.1:27017'
-          }
-          EOS
-        end
-
-        it do
-          is_expected.to create_class('pulp')
-            .with_db_name('pulp_db')
-            .with_db_username('pulp_user')
-            .with_db_password('pulp_pw')
-            .with_db_seeds('192.168.1.1:27017')
+          it do
+            is_expected.to create_class('pulp')
+              .with_db_name('pulp_db')
+              .with_db_username('pulp_user')
+              .with_db_password('pulp_pw')
+              .with_db_seeds('192.168.1.1:27017')
+          end
         end
       end
     end

--- a/spec/classes/katello_pulp_spec.rb
+++ b/spec/classes/katello_pulp_spec.rb
@@ -67,6 +67,13 @@ describe 'katello::pulp' do
               .with_group('foreman')
               .with_mode('0755')
           end
+
+          context 'with repo present' do
+            let(:pre_condition) { super() + 'include katello::repo' }
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to create_class('pulp').that_requires(['Anchor[katello::repo]', 'Yumrepo[katello]']) }
+          end
         end
 
         context 'database parameters' do

--- a/spec/classes/katello_repo_spec.rb
+++ b/spec/classes/katello_repo_spec.rb
@@ -1,37 +1,35 @@
 require 'spec_helper'
 
 describe 'katello::repo' do
-  context 'with manage_repo => false' do
-    let :params do
-      {
-        'manage_repo'  => false,
-        'repo_version' => 'latest',
-        'dist'         => 'el7',
-        'gpgcheck'     => false,
-        'gpgkey'       => '',
-      }
-    end
-
-    it { is_expected.not_to contain_yumrepo('katello') }
-  end
-
-  context 'with manage_repo => true' do
-    let :params do
-      {
-        'manage_repo'  => true,
-        'repo_version' => 'latest',
-        'dist'         => 'el7',
-        'gpgcheck'     => false,
-        'gpgkey'       => '',
-      }
-    end
+  context 'with default parameters' do
+    let(:facts) { { operatingsystemmajrelease: '7' } }
 
     it do
       is_expected.to contain_yumrepo('katello')
         .with_descr('katello latest')
         .with_baseurl("https://fedorapeople.org/groups/katello/releases/yum/latest/katello/el7/\$basearch/")
-        .with_gpgkey('')
+        .with_gpgkey('absent')
         .with_gpgcheck(false)
+        .with_enabled(true)
+    end
+  end
+
+  context 'with manage_repo => true' do
+    let :params do
+      {
+        'repo_version' => '3.14',
+        'dist'         => 'el8',
+        'gpgcheck'     => true,
+        'gpgkey'       => 'https://yum.theforeman.org/releases/1.24/RPM-GPG-KEY-foreman',
+      }
+    end
+
+    it do
+      is_expected.to contain_yumrepo('katello')
+        .with_descr('katello 3.14')
+        .with_baseurl("https://fedorapeople.org/groups/katello/releases/yum/3.14/katello/el8/\$basearch/")
+        .with_gpgkey('https://yum.theforeman.org/releases/1.24/RPM-GPG-KEY-foreman')
+        .with_gpgcheck(true)
         .with_enabled(true)
     end
   end

--- a/spec/classes/katello_spec.rb
+++ b/spec/classes/katello_spec.rb
@@ -6,7 +6,6 @@ describe 'katello' do
       let(:facts) { facts }
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_class('katello::repo') }
       it { is_expected.to contain_class('katello::candlepin') }
       it { is_expected.to contain_class('katello::application') }
       it { is_expected.to contain_class('katello::pulp') }


### PR DESCRIPTION
While it's not possible to collect classes, it is possible to collect anchors. This allows including it anywhere and the right dependency will be set.

This is used to simplify the main class. As an example, the katello::repo is extracted. Ideally all classes become standalone so they can be exposed to the user in the installer. It also makes it easy to do split deployments.