### PR TITLE
Drop old workarounds

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -46,14 +46,6 @@ class katello::application (
     require        => [Class['certs::pulp_client'], Foreman::Rake['db:seed']],
   }
 
-  # We used to override permissions here so this matches it back to the packaging
-  file { '/usr/share/foreman/bundler.d/katello.rb':
-    ensure => file,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
-  }
-
   include foreman::plugin::tasks
 
   Class['certs', 'certs::ca', 'certs::apache'] ~> Class['apache::service']

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,9 +47,6 @@ class katello::params {
   $pulp_url      = "https://${facts['fqdn']}/pulp/api/v2/"
   $crane_url  = "https://${facts['fqdn']}:5000"
 
-  # database reinitialization flag
-  $reset_data = 'NONE'
-
   $qpid_hostname = 'localhost'
   $qpid_interface = 'lo'
   $qpid_url = "amqp:ssl:${qpid_hostname}:5671"

--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -25,13 +25,6 @@ class katello::qpid (
 
   User<|title == $katello_user|>{groups +> 'qpidd'}
 
-  qpid::config_cmd { 'delete katello entitlements queue if bound to *.*':
-    command  => "del queue ${candlepin_event_queue} --force",
-    onlyif   => "list binding | grep ${candlepin_event_queue} | grep '*.*'",
-    ssl_cert => $certs::qpid::client_cert,
-    ssl_key  => $certs::qpid::client_key,
-    hostname => $hostname,
-  } ->
   qpid::config::queue { $candlepin_event_queue:
     ssl_cert => $certs::qpid::client_cert,
     ssl_key  => $certs::qpid::client_key,

--- a/spec/classes/katello_application_spec.rb
+++ b/spec/classes/katello_application_spec.rb
@@ -36,7 +36,6 @@ describe 'katello::application' do
 
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to create_package('tfm-rubygem-katello') }
-          it { is_expected.to create_file('/usr/share/foreman/bundler.d/katello.rb') }
           it { is_expected.to contain_class('certs::qpid') }
           it { is_expected.to contain_class('katello::qpid_client') }
 

--- a/spec/classes/katello_qpid_spec.rb
+++ b/spec/classes/katello_qpid_spec.rb
@@ -31,14 +31,6 @@ describe 'katello::qpid' do
         end
 
         it do
-          is_expected.to create_qpid__config_cmd('delete katello entitlements queue if bound to *.*')
-            .with_command('del queue katello_event_queue --force')
-            .with_onlyif("list binding | grep katello_event_queue | grep '*.*'")
-            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
-        end
-
-        it do
           is_expected.to create_qpid__config__queue('katello_event_queue')
             .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
             .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
@@ -67,14 +59,6 @@ describe 'katello::qpid' do
         it do
           is_expected.to create_class('qpid')
             .with_wcache_page_size(4)
-        end
-
-        it do
-          is_expected.to create_qpid__config_cmd('delete katello entitlements queue if bound to *.*')
-            .with_command('del queue katello_event_queue --force')
-            .with_onlyif("list binding | grep katello_event_queue | grep '*.*'")
-            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
         end
 
         it do


### PR DESCRIPTION
76a9876 Drop katello entitlements queue cleanup

ba8aae68386aa352149822fd9937decdf2677232 started to drop the entitlements queue bound to *.*. Sufficient time has passed to assume all these instances have been cleaned up and can be removed.

c55aa32 Remove bundler.d/katello.rb

In 6476f28f50e8256615403b07ce447d3315d70d85 this file was changed to set the permissions to match packaging. Sufficient time has passed to assume all setups have been upgraded so this cleanup can be removed.