### PR TITLE
Redesign classes to allow split deployments

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -1,26 +1,41 @@
-# Katello configuration for candlepin
+# @summary Install and configure candlepin
+#
+# @param db_host
+#   The database host
+# @param db_port
+#   The database port
+# @param db_name
+#   The database name
+# @param db_user
+#   The database username
+# @param db_password
+#   The database password. A random password will be generated when
+#   unspecified.
+# @param db_ssl
+#   Whether to connect using SSL
+# @param db_ssl_verify
+#   Whether to verify the certificate of the database host
+# @param manage_db
+#   Whether to manage the database. Set this to false when using a remote database
 class katello::candlepin (
-  Variant[Array[String], String] $user_groups = $katello::user_groups,
-  String $oauth_key = $katello::candlepin_oauth_key,
-  String $oauth_secret = $katello::candlepin_oauth_secret,
-  String $db_host = $katello::candlepin_db_host,
-  Optional[Integer[0, 65535]] $db_port = $katello::candlepin_db_port,
-  String $db_name = $katello::candlepin_db_name,
-  String $db_user = $katello::candlepin_db_user,
-  String $db_password = $katello::candlepin_db_password,
-  Boolean $db_ssl = $katello::candlepin_db_ssl,
-  Boolean $db_ssl_verify = $katello::candlepin_db_ssl_verify,
-  Boolean $manage_db = $katello::candlepin_manage_db,
-  String $qpid_hostname = $katello::qpid_hostname,
+  Stdlib::Host $db_host = 'localhost',
+  Optional[Stdlib::Port] $db_port = undef,
+  String $db_name = 'candlepin',
+  String $db_user = 'candlepin',
+  Optional[String] $db_password = undef,
+  Boolean $db_ssl = false,
+  Boolean $db_ssl_verify = true,
+  Boolean $manage_db = true,
 ) {
   include certs
   include certs::candlepin
+  include katello::params
 
   Anchor <| title == 'katello::qpid::event_queue' |> ->
   class { 'candlepin':
-    user_groups                  => $user_groups,
-    oauth_key                    => $oauth_key,
-    oauth_secret                 => $oauth_secret,
+    user_groups                  => $certs::candlepin::group,
+    oauth_key                    => $katello::params::candlepin_oauth_key,
+    oauth_secret                 => $katello::params::candlepin_oauth_secret,
     ca_key                       => $certs::candlepin::ca_key,
     ca_cert                      => $certs::candlepin::ca_cert,
     keystore_file                => $certs::candlepin::keystore,
@@ -34,7 +49,7 @@ class katello::candlepin (
     amqp_truststore_password     => $certs::candlepin::keystore_password,
     amqp_keystore                => $certs::candlepin::amqp_keystore,
     amqp_truststore              => $certs::candlepin::amqp_truststore,
-    qpid_hostname                => $qpid_hostname,
+    qpid_hostname                => $katello::params::qpid_hostname,
     qpid_ssl_cert                => $certs::candlepin::client_cert,
     qpid_ssl_key                 => $certs::candlepin::client_key,
     db_host                      => $db_host,

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,0 +1,41 @@
+# @summary Katello Default Params
+#
+# @param enable_ostree
+#   Enable ostree content plugin, this requires an ostree install
+#
+# @param enable_yum
+#   Enable rpm content plugin, including syncing of yum content
+#
+# @param enable_file
+#   Enable generic file content management
+#
+# @param enable_puppet
+#   Enable puppet content plugin
+#
+# @param enable_docker
+#   Enable docker content plugin
+#
+# @param enable_deb
+#   Enable debian content plugin
+#
+class katello::globals(
+  Boolean $enable_ostree = false,
+  Boolean $enable_yum = true,
+  Boolean $enable_file = true,
+  Boolean $enable_puppet = true,
+  Boolean $enable_docker = true,
+  Boolean $enable_deb = true,
+) {
+  if versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
+    $rubygem_katello = 'rubygem-katello'
+  } else {
+    $rubygem_katello = 'tfm-rubygem-katello'
+  }
+
+  # OAUTH settings
+  $candlepin_oauth_key = 'katello'
+  $candlepin_oauth_secret = extlib::cache_data('foreman_cache_data', 'candlepin_oauth_secret', extlib::random_password(32))
+
+  $candlepin_qpid_exchange = 'event'
+  $candlepin_event_queue = 'katello_event_queue'
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,86 +1,31 @@
-# Katello Default Params
-class katello::params {
-
-  if versioncmp($facts['operatingsystemmajrelease'], '8') >= 0 {
-    $rubygem_katello = 'rubygem-katello'
-  } else {
-    $rubygem_katello = 'tfm-rubygem-katello'
-  }
-  $package_names = ['katello', $rubygem_katello]
-
-  # HTTP Proxy settings (currently used by pulp)
-  $proxy_url = undef
-  $proxy_port = undef
-  $proxy_username = undef
-  $proxy_password = undef
-
-  # Pulp worker settings
-  $num_pulp_workers = min($facts['processorcount'], 8)
-
-  # Pulp max speed setting
-  $pulp_max_speed = undef
-
-  # Rest client timeout
-  $rest_client_timeout = 3600
-
-  # Pulp worker timeout
-  $pulp_worker_timeout = 60
-
-  # Qpid perf settings
-  $qpid_wcache_page_size = 4
-
-  # cdn ssl settings
-  $cdn_ssl_version = undef
-
-  # system settings
-  $user = 'foreman'
-  $group = 'foreman'
-  $user_groups = ['foreman']
-  $repo_export_dir = '/var/lib/pulp/katello-export'
-
-  # OAUTH settings
-  $candlepin_oauth_key = 'katello'
-  $candlepin_oauth_secret = extlib::cache_data('foreman_cache_data', 'candlepin_oauth_secret', extlib::random_password(32))
-
-  # Subsystems settings
-  $candlepin_url = "https://${facts['fqdn']}:8443/candlepin"
-  $pulp_url      = "https://${facts['fqdn']}/pulp/api/v2/"
-  $crane_url  = "https://${facts['fqdn']}:5000"
-
-  $qpid_hostname = 'localhost'
-  $qpid_interface = 'lo'
-  $qpid_url = "amqp:ssl:${qpid_hostname}:5671"
-  $candlepin_event_queue = 'katello_event_queue'
-  $candlepin_qpid_exchange = 'event'
-  $enable_ostree = false
-  $enable_yum = true
-  $enable_file = true
-  $enable_puppet = true
-  $enable_docker = true
-  $enable_deb = true
-
-  # candlepin database settings
-  $candlepin_db_host = 'localhost'
-  $candlepin_db_port = undef
-  $candlepin_db_name = 'candlepin'
-  $candlepin_db_user = 'candlepin'
-  $candlepin_db_password = extlib::cache_data('foreman_cache_data', 'candlepin_db_password', extlib::random_password(32))
-  $candlepin_db_ssl = false
-  $candlepin_db_ssl_verify = true
-  $candlepin_manage_db = true
-
-  # pulp database settings
-  $pulp_manage_db = true
-  $pulp_db_name = 'pulp_database'
-  $pulp_db_seeds = 'localhost:27017'
-  $pulp_db_username = undef
-  $pulp_db_password = undef
-  $pulp_db_replica_set = undef
-  $pulp_db_ssl = false
-  $pulp_db_ssl_keyfile = undef
-  $pulp_db_ssl_certfile = undef
-  $pulp_db_verify_ssl = true
-  $pulp_db_ca_path = '/etc/pki/tls/certs/ca-bundle.crt'
-  $pulp_db_unsafe_autoretry = false
-  $pulp_db_write_concern = undef
+# @summary An indirection layer for parameters
+# @api private
+#
+# The goal of this class is to add all variables defined in katello::globals as
+# class parameters. This will allow users of a distributed setup to override
+# variables.
+#
+# This is a reversed model compared to the "regular" globals, but the
+# parameters on globals are reserved for the foreman-installer
+#
+# @param candlepin_url
+#   The URL to connect to Candlepin
+# @param pulp_url
+#   The URL to connect to Pulp
+# @param crane_url
+#   The URL to connect to Crane
+# @param qpid_hostname
+#   QPID's hostname to connect
+# @param candlepin_oauth_key
+#   The oauth key for Candlepin
+# @param candlepin_oauth_secret
+#   The oauth secret for Candlepin
+class katello::params (
+  Stdlib::Httpsurl $candlepin_url = "https://${facts['fqdn']}:8443/candlepin",
+  Stdlib::Httpsurl $pulp_url = "https://${facts['fqdn']}/pulp/api/v2/",
+  Stdlib::Httpsurl $crane_url = "https://${facts['fqdn']}:5000",
+  Stdlib::Host $qpid_hostname = 'localhost',
+  String[1] $candlepin_oauth_key = $katello::globals::candlepin_oauth_key,
+  String[1] $candlepin_oauth_secret = $katello::globals::candlepin_oauth_secret,
+) inherits katello::globals {
 }

--- a/manifests/qpid_client.pp
+++ b/manifests/qpid_client.pp
@@ -1,6 +1,8 @@
-# Install and configure a qpid client.
-# This is used by the Katello rails app to connect to the
-# qpid message broker.
+# @summary Install and configure a qpid client.
+# @api private
+#
+# This is used by the Katello Rails app to connect to the
+# qpid message broker as well as Pulp
 class katello::qpid_client {
   include certs
   include certs::qpid

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -4,253 +4,54 @@ describe 'katello::application' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let (:params) { {} }
 
-      let(:base_params) do
-        {
-          :package_names          => ['tfm-rubygem-katello'],
-          :enable_ostree          => false,
-          :enable_yum             => true,
-          :enable_file            => true,
-          :enable_puppet          => true,
-          :enable_docker          => true,
-          :enable_deb             => true,
-          :cdn_ssl_version        => '',
-          :candlepin_url          => 'https://foo.example.com:8443/candlepin',
-          :candlepin_oauth_key    => 'candlepin',
-          :candlepin_oauth_secret => 'candlepin-secret',
-          :pulp_url               => 'https://foo.example.com/pulp/api/v2/',
-          :crane_url              => 'https://foo.example.com:5000',
-          :qpid_url               => 'amqp:ssl:localhost:5671',
-          :candlepin_event_queue  => 'katello_event_queue',
-          :proxy_host             => '',
-          :proxy_port             => 8080,
-          :proxy_username         => nil,
-          :proxy_password         => nil,
-          :rest_client_timeout    => 3600,
+      let(:pre_condition) do
+        <<-PUPPET
+        class { 'katello::params':
+          candlepin_oauth_secret => 'candlepin-secret',
         }
+        PUPPET
       end
 
-      context 'with explicit parameters' do
-        context 'with base_params' do
-          let (:params) { base_params }
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to create_package('tfm-rubygem-katello') }
-          it { is_expected.not_to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
-          it { is_expected.to contain_class('certs::qpid') }
-          it { is_expected.to contain_class('katello::qpid_client') }
-
-          it do
-            is_expected.to create_foreman_config_entry('pulp_client_cert')
-              .with_value('/etc/pki/katello/certs/pulp-client.crt')
-              .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-          end
-
-          it do
-            is_expected.to create_foreman_config_entry('pulp_client_key')
-              .with_value('/etc/pki/katello/private/pulp-client.key')
-              .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-          end
-
-          it do
-            is_expected.to contain_service('httpd')
-              .that_subscribes_to(['Class[Certs::Apache]', 'Class[Certs::Ca]'])
-          end
-
-          it do
-            is_expected.to contain_file('/etc/foreman/plugins/katello.yaml')
-              .that_notifies(['Class[Foreman::Service]', 'Exec[foreman-rake-db:seed]', 'Exec[restart_foreman]'])
-          end
-
-          it do
-            is_expected.to create_foreman__config__apache__fragment('katello')
-              .without_content()
-              .with_ssl_content(%r{^<LocationMatch /rhsm\|/katello/api>$})
-          end
-
-          it do
-            is_expected.to contain_class('certs::qpid')
-              .that_notifies(['Class[Foreman::Plugin::Tasks]'])
-          end
-
-          it 'should generate correct katello.yaml' do
-            verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
-              ':katello:',
-              '  :rest_client_timeout: 3600',
-              '  :content_types:',
-              '    :yum: true',
-              '    :file: true',
-              '    :deb: true',
-              '    :puppet: true',
-              '    :docker: true',
-              '    :ostree: false',
-              '  :candlepin:',
-              '    :url: https://foo.example.com:8443/candlepin',
-              '    :oauth_key: "candlepin"',
-              '    :oauth_secret: "candlepin-secret"',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
-              '  :pulp:',
-              '    :url: https://foo.example.com/pulp/api/v2/',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
-              '  :qpid:',
-              '    :url: amqp:ssl:localhost:5671',
-              '    :subscriptions_queue_address: katello_event_queue',
-              '  :container_image_registry:',
-              '    :crane_url: https://foo.example.com:5000',
-              '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
-            ])
-          end
-
-          context 'with repo present' do
-            let(:pre_condition) { 'include katello::repo' }
-
-            it { is_expected.to compile.with_all_deps }
-            it { is_expected.to create_package('tfm-rubygem-katello').that_requires(['Anchor[katello::repo]', 'Yumrepo[katello]']) }
-          end
-        end
-
-        context 'with enable_ostree => true' do
-          let :params do
-            base_params.merge(:enable_ostree => true)
-          end
-
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'with rest client timeout' do
-          let :params do
-            base_params.merge(:rest_client_timeout => 4000)
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          it 'should generate correct katello.yaml' do
-            verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
-              ':katello:',
-              '  :rest_client_timeout: 4000',
-              '  :content_types:',
-              '    :yum: true',
-              '    :file: true',
-              '    :deb: true',
-              '    :puppet: true',
-              '    :docker: true',
-              '    :ostree: false',
-              '  :candlepin:',
-              '    :url: https://foo.example.com:8443/candlepin',
-              '    :oauth_key: "candlepin"',
-              '    :oauth_secret: "candlepin-secret"',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
-              '  :pulp:',
-              '    :url: https://foo.example.com/pulp/api/v2/',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
-              '  :qpid:',
-              '    :url: amqp:ssl:localhost:5671',
-              '    :subscriptions_queue_address: katello_event_queue',
-              '  :container_image_registry:',
-              '    :crane_url: https://foo.example.com:5000',
-              '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
-            ])
-          end
-        end
-
-        context 'with cdn_ssl_version' do
-          let :params do
-            base_params.merge(:cdn_ssl_version => 'TLSv1')
-          end
-
-          it { is_expected.to compile.with_all_deps }
-
-          it 'should generate correct katello.yaml' do
-            verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
-              ':katello:',
-              '  :cdn_ssl_version: TLSv1',
-              '  :rest_client_timeout: 3600',
-              '  :content_types:',
-              '    :yum: true',
-              '    :file: true',
-              '    :deb: true',
-              '    :puppet: true',
-              '    :docker: true',
-              '    :ostree: false',
-              '  :candlepin:',
-              '    :url: https://foo.example.com:8443/candlepin',
-              '    :oauth_key: "candlepin"',
-              '    :oauth_secret: "candlepin-secret"',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
-              '  :pulp:',
-              '    :url: https://foo.example.com/pulp/api/v2/',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
-              '  :qpid:',
-              '    :url: amqp:ssl:localhost:5671',
-              '    :subscriptions_queue_address: katello_event_queue',
-              '  :container_image_registry:',
-              '    :crane_url: https://foo.example.com:5000',
-              '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
-            ])
-          end
-        end
-
-        context 'when http proxy parameters are specified' do
-          let(:params) do
-            base_params.merge(
-              :proxy_host     => 'http://myproxy.org',
-              :proxy_port     => 8888,
-              :proxy_username => 'admin',
-              :proxy_password => 'secret_password',
-            )
-          end
-
-          it 'should generate correct katello.yaml' do
-            verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
-              ':katello:',
-              '  :rest_client_timeout: 3600',
-              '  :content_types:',
-              '    :yum: true',
-              '    :file: true',
-              '    :deb: true',
-              '    :puppet: true',
-              '    :docker: true',
-              '    :ostree: false',
-              '  :candlepin:',
-              '    :url: https://foo.example.com:8443/candlepin',
-              '    :oauth_key: "candlepin"',
-              '    :oauth_secret: "candlepin-secret"',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
-              '  :pulp:',
-              '    :url: https://foo.example.com/pulp/api/v2/',
-              '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
-              '  :qpid:',
-              '    :url: amqp:ssl:localhost:5671',
-              '    :subscriptions_queue_address: katello_event_queue',
-              '  :container_image_registry:',
-              '    :crane_url: https://foo.example.com:5000',
-              '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
-              '  :cdn_proxy:',
-              '    :host: http://myproxy.org',
-              '    :port: 8888',
-              '    :user: "admin"',
-              '    :password: "secret_password"'
-            ])
-          end
-        end
-      end
-
-      context 'with inherited parameters' do
-        let :pre_condition do
-          <<-EOS
-          class {'::katello':
-            candlepin_oauth_key    => 'candlepin',
-            candlepin_oauth_secret => 'candlepin-secret',
-          }
-          EOS
-        end
-
+      context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
-        it { is_expected.to create_package('katello') }
+        it { is_expected.to create_package('tfm-rubygem-katello') }
+        it { is_expected.not_to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
+        it { is_expected.to contain_class('certs::qpid') }
+        it { is_expected.to contain_class('katello::qpid_client') }
+
         it do
-          is_expected.to contain_package('tfm-rubygem-katello')
-            .that_requires('Class[candlepin]')
+          is_expected.to create_foreman_config_entry('pulp_client_cert')
+            .with_value('/etc/pki/katello/certs/pulp-client.crt')
+            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
+        end
+
+        it do
+          is_expected.to create_foreman_config_entry('pulp_client_key')
+            .with_value('/etc/pki/katello/private/pulp-client.key')
+            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
+        end
+
+        it do
+          is_expected.to contain_service('httpd')
+            .that_subscribes_to(['Class[Certs::Apache]', 'Class[Certs::Ca]'])
+        end
+
+        it do
+          is_expected.to contain_file('/etc/foreman/plugins/katello.yaml')
+            .that_notifies(['Class[Foreman::Service]', 'Exec[foreman-rake-db:seed]', 'Exec[restart_foreman]'])
+        end
+
+        it do
+          is_expected.to create_foreman__config__apache__fragment('katello')
+            .without_content()
+            .with_ssl_content(%r{^<LocationMatch /rhsm\|/katello/api>$})
+        end
+
+        it do
+          is_expected.to contain_class('certs::qpid')
+            .that_notifies(['Class[Foreman::Plugin::Tasks]'])
         end
 
         it 'should generate correct katello.yaml' do
@@ -266,7 +67,7 @@ describe 'katello::application' do
             '    :ostree: false',
             '  :candlepin:',
             '    :url: https://foo.example.com:8443/candlepin',
-            '    :oauth_key: "candlepin"',
+            '    :oauth_key: "katello"',
             '    :oauth_secret: "candlepin-secret"',
             '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
             '  :pulp:',
@@ -282,6 +83,108 @@ describe 'katello::application' do
         end
       end
 
+      context 'with repo present' do
+        let(:pre_condition) { 'include katello::repo' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_package('tfm-rubygem-katello').that_requires(['Anchor[katello::repo]', 'Yumrepo[katello]']) }
+      end
+
+      context 'with parameters' do
+        let(:params) do
+          {
+            rest_client_timeout: 4000,
+            cdn_ssl_version: 'TLSv1',
+            proxy_host: 'myproxy.example.org',
+            proxy_port: 8888,
+            proxy_username: 'admin',
+            proxy_password: 'secret_password',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should generate correct katello.yaml' do
+          verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
+            ':katello:',
+            '  :cdn_ssl_version: TLSv1',
+            '  :rest_client_timeout: 4000',
+            '  :content_types:',
+            '    :yum: true',
+            '    :file: true',
+            '    :deb: true',
+            '    :puppet: true',
+            '    :docker: true',
+            '    :ostree: false',
+            '  :candlepin:',
+            '    :url: https://foo.example.com:8443/candlepin',
+            '    :oauth_key: "katello"',
+            '    :oauth_secret: "candlepin-secret"',
+            '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '  :pulp:',
+            '    :url: https://foo.example.com/pulp/api/v2/',
+            '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
+            '  :qpid:',
+            '    :url: amqp:ssl:localhost:5671',
+            '    :subscriptions_queue_address: katello_event_queue',
+            '  :container_image_registry:',
+            '    :crane_url: https://foo.example.com:5000',
+            '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
+            '  :cdn_proxy:',
+            '    :host: myproxy.example.org',
+            '    :port: 8888',
+            '    :user: "admin"',
+            '    :password: "secret_password"',
+          ])
+        end
+      end
+
+      context 'with inherited parameters' do
+        let :pre_condition do
+          <<-EOS
+          class {'katello::globals':
+            enable_ostree => true,
+          }
+          #{super()}
+          EOS
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should generate correct katello.yaml' do
+          verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', [
+            ':katello:',
+            '  :rest_client_timeout: 3600',
+            '  :content_types:',
+            '    :yum: true',
+            '    :file: true',
+            '    :deb: true',
+            '    :puppet: true',
+            '    :docker: true',
+            '    :ostree: true',
+            '  :candlepin:',
+            '    :url: https://foo.example.com:8443/candlepin',
+            '    :oauth_key: "katello"',
+            '    :oauth_secret: "candlepin-secret"',
+            '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '  :pulp:',
+            '    :url: https://foo.example.com/pulp/api/v2/',
+            '    :ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
+            '  :qpid:',
+            '    :url: amqp:ssl:localhost:5671',
+            '    :subscriptions_queue_address: katello_event_queue',
+            '  :container_image_registry:',
+            '    :crane_url: https://foo.example.com:5000',
+            '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
+          ])
+        end
+      end
+
+      context 'with candlepin' do
+        let(:pre_condition) { super() + 'include katello::candlepin' }
+
+        it { is_expected.to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
+      end
     end
   end
 end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -5,38 +5,21 @@ describe 'katello::candlepin' do
     context "on #{os}" do
       let (:facts) { facts }
 
-      context 'with explicit parameters' do
-        let(:params) do
-          {
-            :user_groups    => ['foreman'],
-            :oauth_key      => 'candlepin',
-            :oauth_secret   => 'secret',
-            :db_host        => 'localhost',
-            :db_port        => 5432,
-            :db_name        => 'candlepin',
-            :db_user        => 'candlepin',
-            :db_password    => 'secret',
-            :db_ssl         => false,
-            :db_ssl_verify  => true,
-            :manage_db      => true,
-            :qpid_hostname  => 'localhost',
-          }
-        end
-
+      context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('candlepin') }
+        it { is_expected.to create_class('candlepin') }
         it { is_expected.not_to contain_class('candlepin').that_requires('Anchor[katello::qpid::event_queue]') }
       end
 
-      context 'with inherited parameters' do
-        let :pre_condition do
-          'include katello'
-        end
+      context 'with qpid parameters' do
+        let(:pre_condition) { 'include katello::qpid' }
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('candlepin').that_requires('Anchor[katello::qpid::event_queue]') }
+        it 'should require a complete event queue' do
+          is_expected.to compile.with_all_deps
+          is_expected.to contain_anchor('katello::qpid::event_queue')
+          is_expected.to create_class('candlepin').that_requires('Anchor[katello::qpid::event_queue]')
+        end
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'katello' do
       it { is_expected.to contain_class('katello::qpid_client') }
       it { is_expected.to contain_class('katello::qpid') }
 
-      it { is_expected.to contain_package('katello').that_requires('Class[candlepin]') }
+      it { is_expected.to contain_package('tfm-rubygem-katello').that_requires('Class[candlepin]') }
 
       it { is_expected.to contain_service('tomcat').that_requires('Qpid::Config::Bind[entitlement.created]') }
     end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -3,78 +3,40 @@ require 'spec_helper'
 describe 'katello::qpid' do
   on_os_under_test.each do |os, facts|
     context "on #{os}" do
-      let :facts do
-        facts
+      let(:facts) { facts }
+
+      context 'with default parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('certs::qpid').that_notifies(['Service[qpidd]', 'Class[qpid]']) }
+        it { is_expected.to create_class('qpid').with_wcache_page_size(4).with_interface('lo') }
+
+        it do
+          is_expected.to create_qpid__config__queue('katello_event_queue')
+            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
+            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
+        end
+
+        ['entitlement.created', 'entitlement.deleted', 'pool.created', 'pool.deleted', 'compliance.created', 'system_purpose_compliance.created'].each do |binding|
+          it do
+            is_expected.to create_qpid__config__bind(binding)
+              .with_queue('katello_event_queue')
+              .with_exchange('event')
+              .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
+              .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
+          end
+        end
       end
 
-      context 'with explicit parameters' do
+      context 'with overridden parameters' do
         let :params do
           {
-            :katello_user            => 'foreman',
-            :candlepin_event_queue   => 'katello_event_queue',
-            :candlepin_qpid_exchange => 'event',
-            :wcache_page_size        => 8,
-            :interface               => 'eth0',
-            :hostname                => 'localhost',
+            wcache_page_size: 8,
           }
         end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_class('certs') }
-        it { is_expected.to contain_class('certs::qpid').that_notifies(['Service[qpidd]', 'Class[qpid]']) }
-        it { is_expected.not_to contain_user('foreman') }
-
-        it do
-          is_expected.to create_class('qpid')
-            .with_wcache_page_size(8)
-            .with_interface('eth0')
-        end
-
-        it do
-          is_expected.to create_qpid__config__queue('katello_event_queue')
-            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
-        end
-
-        ['entitlement.created', 'entitlement.deleted', 'pool.created', 'pool.deleted', 'compliance.created', 'system_purpose_compliance.created'].each do |binding|
-          it do
-            is_expected.to create_qpid__config__bind(binding)
-              .with_queue('katello_event_queue')
-              .with_exchange('event')
-              .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-              .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
-          end
-        end
-      end
-
-      context 'with inherited parameters' do
-        let :pre_condition do
-          'include katello'
-        end
-
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_user('foreman').with_groups(['puppet', 'qpidd']) }
-        it { is_expected.to contain_class('certs::qpid').that_notifies(['Service[qpidd]', 'Class[qpid]']) }
-
-        it do
-          is_expected.to create_class('qpid')
-            .with_wcache_page_size(4)
-        end
-
-        it do
-          is_expected.to create_qpid__config__queue('katello_event_queue')
-            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
-        end
-
-        ['entitlement.created', 'entitlement.deleted', 'pool.created', 'pool.deleted', 'compliance.created', 'system_purpose_compliance.created'].each do |binding|
-          it do
-            is_expected.to create_qpid__config__bind(binding)
-              .with_queue('katello_event_queue')
-              .with_exchange('event')
-              .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-              .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
-          end
+        it 'should pass the variable' do
+          is_expected.to compile.with_all_deps
+          is_expected.to create_class('qpid').with_wcache_page_size(8)
         end
       end
     end


### PR DESCRIPTION
Every class that provides an aspect of the deployment is now standalone. This means:

* candlepin
* pulp
* qpid
* application

They can just be included and work by themselves. All class parameters are tunables that users will commonly modify.

There's also shared parameters which are common among the standalone classes. These are meant to be changed via katello::params. Either via Hiera or by including them in a profile class before the instance classes themselves.

The katello::globals class has globals that a user via the installer might want to change. The katello::params class is not intended to be exposed via the installer.

Currently a draft because I want to do testing with rewriting the changes in the installer. Having this in a PR makes that easier.

Includes:
* https://github.com/theforeman/puppet-katello/pull/306
* https://github.com/theforeman/puppet-katello/pull/307 (only the drop unused variable)