### PR TITLE
Use Stdlib::Httpurl datatype to support setting a proxy protocol

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -21,7 +21,7 @@
 class katello::application (
   Integer[0] $rest_client_timeout = 3600,
   Optional[Enum['SSLv23', 'TLSv1', '']] $cdn_ssl_version = undef,
-  Optional[Stdlib::Host] $proxy_host = undef,
+  Optional[Stdlib::HTTPUrl] $proxy_host = undef,
   Optional[Stdlib::Port] $proxy_port = undef,
   Optional[String] $proxy_username = undef,
   Optional[String] $proxy_password = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,7 +111,7 @@ class katello (
   Stdlib::Host $qpid_hostname = 'localhost',
   Optional[Integer[1]] $num_pulp_workers = undef,
   Integer[0] $pulp_worker_timeout = 60,
-  Optional[Stdlib::Host] $proxy_url = undef,
+  Optional[Stdlib::HTTPUrl] $proxy_url = undef,
   Optional[Stdlib::Port] $proxy_port = undef,
   Optional[String] $proxy_username = undef,
   Optional[String] $proxy_password = undef,

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -95,7 +95,7 @@ describe 'katello::application' do
           {
             rest_client_timeout: 4000,
             cdn_ssl_version: 'TLSv1',
-            proxy_host: 'myproxy.example.org',
+            proxy_host: 'http://myproxy.example.org',
             proxy_port: 8888,
             proxy_username: 'admin',
             proxy_password: 'secret_password',
@@ -131,7 +131,7 @@ describe 'katello::application' do
             '    :crane_url: https://foo.example.com:5000',
             '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt',
             '  :cdn_proxy:',
-            '    :host: myproxy.example.org',
+            '    :host: http://myproxy.example.org',
             '    :port: 8888',
             '    :user: "admin"',
             '    :password: "secret_password"',


### PR DESCRIPTION
We need to support Strings as well because we might need the protocol for the proxy.
E.g. this Katello seed will fail if the proxy is specified without a protocol: https://github.com/Katello/katello/blob/master/db/seeds.d/115-http_proxy.rb#L3

The datatype was changed in https://github.com/theforeman/puppet-katello/pull/308