### PR TITLE
Support manage_httpd to allow Pulp in a standalone setup

### DIFF
--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -85,6 +85,17 @@ describe 'katello::pulp' do
               .with_db_password('pulp_pw')
               .with_db_seeds('192.168.1.1:27017')
           end
+
+          context 'with manage_httpd => true' do
+            let :params do
+              super().merge({ 'manage_httpd' => true, })
+            end
+
+            it do
+              is_expected.to create_class('pulp')
+                .with_manage_httpd(true)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Follow up to https://github.com/theforeman/puppet-katello/pull/304  and https://github.com/theforeman/puppet-katello/pull/308

This PR enables Pulp to exist as a standalone system and therefore enables split deployments.

The default behaviour does not change in any way. It it explicitly required to set a least `manage_httpd` to `true`.