### PR TITLE
Compatibility with katello/certs 7.x

### DIFF
--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -87,7 +87,12 @@ class katello::pulp (
 ) {
   include katello::params
   include certs
-  include certs::qpid_client
+
+  class { 'certs::qpid_client':
+    require => Class['pulp::install'],
+    notify  => Class['pulp::service'],
+  }
+
   include apache
 
   # Deploy as a part of the foreman vhost
@@ -124,7 +129,7 @@ class katello::pulp (
     repo_auth              => true,
     puppet_wsgi_processes  => 1,
     enable_katello         => true,
-    subscribe              => Class['certs', 'certs::qpid_client'],
+    subscribe              => Class['certs'],
     worker_timeout         => $worker_timeout,
     db_name                => $mongodb_name,
     db_seeds               => $mongodb_seeds,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 6.1.1 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 8.0.0"
     },
     {
       "name": "katello/pulp",

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -9,7 +9,8 @@ describe 'katello::pulp' do
         context 'minimal set' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_class('certs') }
-          it { is_expected.to contain_class('certs::qpid_client') }
+          # pulp-server creates the pulp group which qpid_client uses
+          it { is_expected.to contain_class('certs::qpid_client').that_requires('Package[pulp-server]').that_notifies('Service[pulp_workers]') }
 
           it do
             is_expected.to create_class('pulp')
@@ -39,7 +40,6 @@ describe 'katello::pulp' do
               .with_db_name('pulp_database')
               .with_db_seeds('localhost:27017')
               .with_db_ssl(false)
-              .that_subscribes_to('Class[Certs::Qpid_client]')
           end
 
           it do


### PR DESCRIPTION
certs 7.0.0 started to create qpid files owned by the pulp group. This group is created by pulp-server which is in pulp::install. This more specific chaining avoids dependency cycles.

This is an alternative to https://github.com/theforeman/puppet-certs/pull/270. Related to https://github.com/theforeman/puppet-certs/pull/272.