### PR TITLE
Refs #29039 - Use foreman's Apache config standalone

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -12,11 +12,15 @@
 # @param use_pulp_2_for_docker
 #  Configure Katello to use Pulp 2 for docker content
 #
+# @param repo_export_dir
+#   Create a repository export directory for Katello to use
+#
 class katello::application (
   Integer[0] $rest_client_timeout = 3600,
   Optional[Enum['SSLv23', 'TLSv1', '']] $cdn_ssl_version = undef,
   Boolean $use_pulp_2_for_file = false,
   Boolean $use_pulp_2_for_docker = false,
+  Stdlib::Absolutepath $repo_export_dir = '/var/lib/pulp/katello-export',
 ) {
   include foreman
   include certs
@@ -86,5 +90,17 @@ class katello::application (
     foreman::dynflow::worker { 'worker-hosts-queue':
       queues => ['hosts_queue'],
     }
+  }
+
+  Anchor <| title == 'katello::pulp' |> ->
+  exec { "mkdir -p ${repo_export_dir}":
+    path    => ['/bin', '/usr/bin'],
+    creates => $repo_export_dir,
+  } ->
+  file { $repo_export_dir:
+    ensure => directory,
+    owner  => $foreman::user,
+    group  => $foreman::group,
+    mode   => '0755',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -181,6 +181,14 @@ class katello (
     wcache_page_size => $qpid_wcache_page_size,
   }
 
+  class { 'katello::application':
+    rest_client_timeout   => $rest_client_timeout,
+    cdn_ssl_version       => $cdn_ssl_version,
+    use_pulp_2_for_file   => $use_pulp_2_for_file,
+    use_pulp_2_for_docker => $use_pulp_2_for_docker,
+    repo_export_dir       => $repo_export_dir,
+  }
+
   class { 'katello::pulp':
     yum_max_speed            => $pulp_max_speed,
     num_workers              => $num_pulp_workers,
@@ -199,13 +207,4 @@ class katello (
     mongodb_write_concern    => $pulp_db_write_concern,
     manage_mongodb           => $pulp_manage_db,
   }
-
-  class { 'katello::application':
-    rest_client_timeout   => $rest_client_timeout,
-    cdn_ssl_version       => $cdn_ssl_version,
-    use_pulp_2_for_file   => $use_pulp_2_for_file,
-    use_pulp_2_for_docker => $use_pulp_2_for_docker,
-    repo_export_dir       => $repo_export_dir,
-  }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -198,7 +198,6 @@ class katello (
     mongodb_unsafe_autoretry => $pulp_db_unsafe_autoretry,
     mongodb_write_concern    => $pulp_db_write_concern,
     manage_mongodb           => $pulp_manage_db,
-    repo_export_dir          => $repo_export_dir,
   }
 
   class { 'katello::application':
@@ -206,6 +205,7 @@ class katello (
     cdn_ssl_version       => $cdn_ssl_version,
     use_pulp_2_for_file   => $use_pulp_2_for_file,
     use_pulp_2_for_docker => $use_pulp_2_for_docker,
+    repo_export_dir       => $repo_export_dir,
   }
 
 }

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -93,8 +93,8 @@ class katello::pulp (
   include apache
 
   # Deploy as a part of the foreman vhost
-  include foreman
-  $server_name = $foreman::servername
+  include foreman::config::apache
+  $server_name = $foreman::config::apache::servername
   foreman::config::apache::fragment { 'pulp':
     content     => template('katello/pulp-apache.conf.erb'),
     ssl_content => template('katello/pulp-apache-ssl.conf.erb'),

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -63,8 +63,6 @@
 # @param pub_dir_options
 #   The Apache options to use on the `/pub` resource
 #
-# @param repo_export_dir
-#   Create a repository export directory for Katello to use
 class katello::pulp (
   Optional[String] $yum_max_speed = undef,
   Optional[Integer[1]] $num_workers = undef,
@@ -83,7 +81,6 @@ class katello::pulp (
   Optional[Enum['majority', 'all']] $mongodb_write_concern = undef,
   Boolean $manage_mongodb = true,
   String $pub_dir_options = '+FollowSymLinks +Indexes',
-  Stdlib::Absolutepath $repo_export_dir = '/var/lib/pulp/katello-export',
 ) {
   include katello::params
   include certs
@@ -148,11 +145,7 @@ class katello::pulp (
 
   contain pulp
 
-  file { $repo_export_dir:
-    ensure  => directory,
-    owner   => $foreman::user,
-    group   => $foreman::group,
-    mode    => '0755',
+  anchor { 'katello::pulp':
     require => Class['pulp'],
   }
 }

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -88,6 +88,15 @@ describe 'katello::application' do
             '    :crane_ca_cert_file: /etc/pki/katello/certs/katello-server-ca.crt'
           ])
         end
+
+        it do
+          is_expected.to create_file('/var/lib/pulp/katello-export')
+            .with_ensure('directory')
+            .with_owner('foreman')
+            .with_group('foreman')
+            .with_mode('0755')
+            .that_requires('Exec[mkdir -p /var/lib/pulp/katello-export]')
+        end
       end
 
       context 'with repo present' do
@@ -187,7 +196,16 @@ describe 'katello::application' do
       context 'with candlepin' do
         let(:pre_condition) { super() + 'include katello::candlepin' }
 
+        it { is_expected.to compile.with_all_deps }
         it { is_expected.to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
+      end
+
+      context 'with pulp' do
+        # post condition because things are compile order dependent
+        let(:post_condition) { 'include katello::pulp' }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_exec('mkdir -p /var/lib/pulp/katello-export').that_requires(['Anchor[katello::pulp]']) }
       end
     end
   end

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -48,13 +48,7 @@ describe 'katello::pulp' do
               .with_ssl_content(%r{^<Location /pulp/api>$})
           end
 
-          it do
-            is_expected.to create_file('/var/lib/pulp/katello-export')
-              .with_ensure('directory')
-              .with_owner('foreman')
-              .with_group('foreman')
-              .with_mode('0755')
-          end
+          it { is_expected.to create_anchor('katello::pulp').that_requires('Class[pulp]') }
 
           context 'with repo present' do
             let(:pre_condition) { 'include katello::repo' }


### PR DESCRIPTION
By using only the Apache config, it's possible to use the Apache config without Foreman installed.

Depends on https://github.com/theforeman/puppet-foreman/pull/800