### PR TITLE
Fix the tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -24,6 +24,7 @@ fixtures:
       puppet_version: '>= 6.0.0'
     stdlib:        "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     systemd:       "https://github.com/camptocamp/puppet-systemd.git"
+    transition:    "https://github.com/puppetlabs/puppetlabs-transition.git"
     yumrepo_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
       puppet_version: '>= 6.0.0'

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -40,7 +40,7 @@ describe 'katello::application' do
 
         it do
           is_expected.to contain_file('/etc/foreman/plugins/katello.yaml')
-            .that_notifies(['Class[Foreman::Service]', 'Exec[foreman-rake-db:seed]', 'Exec[restart_foreman]'])
+            .that_notifies(['Class[Foreman::Service]', 'Exec[foreman-rake-db:seed]'])
         end
 
         it do


### PR DESCRIPTION
* a57f571 Remove coupled expectation

The `Exec[restart_foreman]` resource is part of `Foreman::Service` when Passenger is used. Since the default flipped, this is no longer the case. Since it's an implementation detail, we no longer need to test for this.

* a48e2d8 Add transition to fixtures

puppet-pulp has started to depend on this.