### PR TITLE
Fix Stdlib::HTTPSUrl type name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,12 +23,12 @@
 # @param candlepin_oauth_secret
 #   The oauth secret for Candlepin
 class katello::params (
-  Stdlib::Httpsurl $pulp_url = "https://${facts['fqdn']}/pulp/api/v2/",
-  Stdlib::Httpsurl $crane_url = "https://${facts['fqdn']}:5000",
+  Stdlib::HTTPSUrl $pulp_url = "https://${facts['fqdn']}/pulp/api/v2/",
+  Stdlib::HTTPSUrl $crane_url = "https://${facts['fqdn']}:5000",
   Stdlib::Host $qpid_hostname = 'localhost',
   String[1] $candlepin_oauth_key = $katello::globals::candlepin_oauth_key,
   String[1] $candlepin_oauth_secret = $katello::globals::candlepin_oauth_secret,
   Stdlib::Host $candlepin_host = 'localhost',
-  Stdlib::Httpsurl $candlepin_url = "https://${candlepin_host}:8443/candlepin"
+  Stdlib::HTTPSUrl $candlepin_url = "https://${candlepin_host}:8443/candlepin"
 ) inherits katello::globals {
 }


### PR DESCRIPTION
The datatype has to be `HTTPSUrl` instead of `Httpsurl` to not break the foreman-installer if using the `params.pp` directly:
```
[root@foreman4xng ~]# foreman-installer --scenario custom --noop --verbose
[FATAL 2020-04-02T08:01:02 fatal] Unable to continue because of: unknown data type Stdlib::Httpsurl
```

I'm not really sure why this works when just including the class without specifying the parameters explicitly (like in https://github.com/theforeman/puppet-katello/blob/master/manifests/init.pp#L159-163)

see https://github.com/puppetlabs/puppetlabs-stdlib#stdlibhttpsurl