### PR TITLE
Support manage_httpd to allow Pulp in a standalone setup (followup)

### DIFF
--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -63,8 +63,8 @@
 # @param pub_dir_options
 #   The Apache options to use on the `/pub` resource
 #
-# @param manage_httpd
-#   Boolean to also manage httpd for Pulp in a standalone setup
+# @param manage_vhost_standalone
+#   Boolean to manage the Pulp vhost standalone. Otherwise the vhost is managed as part of Foreman
 #
 # @param https_cert
 #   The Apache public certificate for ssl
@@ -93,7 +93,7 @@ class katello::pulp (
   Optional[Enum['majority', 'all']] $mongodb_write_concern = undef,
   Boolean $manage_mongodb = true,
   String $pub_dir_options = '+FollowSymLinks +Indexes',
-  Boolean $manage_httpd = false,
+  Boolean $manage_vhost_standalone = false,
   Optional[Stdlib::Absolutepath] $https_cert = undef,
   Optional[Stdlib::Absolutepath] $https_key = undef,
   Optional[Stdlib::Absolutepath] $https_ca_cert = undef,
@@ -108,7 +108,7 @@ class katello::pulp (
 
   include apache
 
-  if $manage_httpd {
+  if $manage_vhost_standalone {
     $server_name = undef
 
     concat::fragment { 'httpd_pub':
@@ -141,7 +141,7 @@ class katello::pulp (
     broker_use_ssl         => true,
     yum_max_speed          => $yum_max_speed,
     manage_broker          => false,
-    manage_httpd           => $manage_httpd,
+    manage_httpd           => $manage_vhost_standalone,
     https_cert             => $https_cert,
     https_key              => $https_key,
     https_ca_cert          => $https_ca_cert,

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -63,6 +63,18 @@
 # @param pub_dir_options
 #   The Apache options to use on the `/pub` resource
 #
+# @param manage_httpd
+#   Boolean to also manage httpd for Pulp in a standalone setup
+#
+# @param https_cert
+#   The Apache public certificate for ssl
+#
+# @param https_key
+#   The Apache private key for ssl
+#
+# @param https_ca_cert
+#   The Apache CA certificate for client authentication
+#
 class katello::pulp (
   Optional[String] $yum_max_speed = undef,
   Optional[Integer[1]] $num_workers = undef,

--- a/manifests/pulp.pp
+++ b/manifests/pulp.pp
@@ -81,6 +81,10 @@ class katello::pulp (
   Optional[Enum['majority', 'all']] $mongodb_write_concern = undef,
   Boolean $manage_mongodb = true,
   String $pub_dir_options = '+FollowSymLinks +Indexes',
+  Boolean $manage_httpd = false,
+  Optional[Stdlib::Absolutepath] $https_cert = undef,
+  Optional[Stdlib::Absolutepath] $https_key = undef,
+  Optional[Stdlib::Absolutepath] $https_ca_cert = undef,
 ) {
   include katello::params
   include certs
@@ -92,12 +96,25 @@ class katello::pulp (
 
   include apache
 
-  # Deploy as a part of the foreman vhost
-  include foreman::config::apache
-  $server_name = $foreman::config::apache::servername
-  foreman::config::apache::fragment { 'pulp':
-    content     => template('katello/pulp-apache.conf.erb'),
-    ssl_content => template('katello/pulp-apache-ssl.conf.erb'),
+  if $manage_httpd {
+    $server_name = undef
+
+    concat::fragment { 'httpd_pub':
+      target  => '05-pulp-http.conf',
+      content => template('katello/pulp-apache.conf.erb'),
+    }
+
+    pulp::apache::fragment { 'httpd_ssl_pub':
+      ssl_content => template('katello/pulp-apache-ssl.conf.erb'),
+    }
+  } else {
+    # Deploy as a part of the foreman vhost
+    include foreman::config::apache
+    $server_name = $foreman::config::apache::servername
+    foreman::config::apache::fragment { 'pulp':
+      content     => template('katello/pulp-apache.conf.erb'),
+      ssl_content => template('katello/pulp-apache-ssl.conf.erb'),
+    }
   }
 
   Anchor <| title == 'katello::repo' |> -> # lint:ignore:anchor_resource
@@ -112,7 +129,10 @@ class katello::pulp (
     broker_use_ssl         => true,
     yum_max_speed          => $yum_max_speed,
     manage_broker          => false,
-    manage_httpd           => false,
+    manage_httpd           => $manage_httpd,
+    https_cert             => $https_cert,
+    https_key              => $https_key,
+    https_ca_cert          => $https_ca_cert,
     manage_plugins_httpd   => true,
     manage_squid           => true,
     enable_rpm             => $katello::params::enable_yum,

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -79,6 +79,17 @@ describe 'katello::pulp' do
               .with_db_password('pulp_pw')
               .with_db_seeds('192.168.1.1:27017')
           end
+
+          context 'with manage_httpd => true' do
+            let :params do
+              super().merge({ 'manage_httpd' => true, })
+            end
+
+            it do
+              is_expected.to create_class('pulp')
+                .with_manage_httpd(true)
+            end
+          end
         end
       end
     end

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -82,7 +82,7 @@ describe 'katello::pulp' do
 
           context 'with manage_httpd => true' do
             let :params do
-              super().merge({ 'manage_httpd' => true, })
+              super().merge({ 'manage_vhost_standalone' => true, })
             end
 
             it do


### PR DESCRIPTION
Follow up to #312

This PR enables Pulp to exist as a standalone system and therefore enables split deployments.

The default behaviour does not change in any way. It it explicitly required to set a least manage_httpd to true.

Note: The original PR is #312. Because the source branch was missing, I needed to open a new PR with an existing branch I can push to.