### PR TITLE
Fixes #29944 - Make hosts_queue number of workers configurable

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -66,6 +66,7 @@ class katello::application (
   $postgresql_debversion_package = $katello::params::postgresql_debversion_package
   $postgresql_evr_package = $katello::params::postgresql_evr_package
   $manage_db = $foreman::db_manage
+  $hosts_queue_workers = $katello::params::hosts_queue_workers
 
   # Katello database seeding needs candlepin
   Anchor <| title == 'katello::repo' or title ==  'katello::candlepin' |> ->
@@ -89,8 +90,10 @@ class katello::application (
   }
 
   if $foreman::jobs_manage_service {
-    foreman::dynflow::worker { 'worker-hosts-queue':
-      queues => ['hosts_queue'],
+    Integer[1, $hosts_queue_workers].each |$n| {
+      foreman::dynflow::worker { "worker-hosts-queue-${n}":
+        queues => ['hosts_queue'],
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,8 @@
 #   The contextual package name for the PostgreSQL debversion extension
 # @param postgresql_evr_package
 #   The contextual package name for the PostgreSQL EVR extension
+# @param hosts_queue_workers
+#   The number of dynflow workers for the Katello hosts_queue
 class katello::params (
   Stdlib::HTTPSUrl $pulp_url = "https://${facts['networking']['fqdn']}/pulp/api/v2/",
   Stdlib::HTTPSUrl $crane_url = "https://${facts['networking']['fqdn']}:5000",
@@ -36,5 +38,6 @@ class katello::params (
   Stdlib::HTTPSUrl $candlepin_url = "https://${candlepin_host}:8443/candlepin",
   String[1] $postgresql_debversion_package = $katello::globals::postgresql_debversion_package,
   String[1] $postgresql_evr_package = $katello::globals::postgresql_evr_package,
+  Integer $hosts_queue_workers = 1
 ) inherits katello::globals {
 }

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -59,7 +59,7 @@ describe 'katello::application' do
         end
 
         it do
-          is_expected.to contain_foreman__dynflow__worker('worker-hosts-queue')
+          is_expected.to contain_foreman__dynflow__worker('worker-hosts-queue-1')
         end
 
         it 'should generate correct katello.yaml' do


### PR DESCRIPTION
Adds support for configuring the number of Dynflow workers for the hosts_queue.

The idea here is to add unique IDs to the `hosts_queue_worker_ids` array to generate more Dynflow workers.

This PR will require a change to foreman-maintain to restart all of the running `worker-hosts-queue` workers.

Questions:
Adding more workers with an array doesn't seem natural to me, but Puppet seems to have limited looping capabilities.  Is there a better way to do this with Puppet?