### PR TITLE
Revert "Add postgresql-debversion extension to katello"

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -63,7 +63,6 @@ class katello::application (
   $candlepin_events_ssl_key = $certs::candlepin::client_key
   $crane_url = $katello::params::crane_url
   $crane_ca_cert = $certs::katello_server_ca_cert
-  $postgresql_debversion_package = $katello::params::postgresql_debversion_package
   $postgresql_evr_package = $katello::params::postgresql_evr_package
   $manage_db = $foreman::db_manage
 
@@ -76,9 +75,6 @@ class katello::application (
   }
 
   if $manage_db {
-    package { $postgresql_debversion_package:
-      ensure => installed,
-    }
     package { $postgresql_evr_package:
       ensure => installed,
     }

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -31,10 +31,8 @@ class katello::globals(
   $candlepin_oauth_secret = extlib::cache_data('foreman_cache_data', 'candlepin_oauth_secret', extlib::random_password(32))
 
   if $facts['os']['release']['major'] == '7' {
-    $postgresql_debversion_package = 'rh-postgresql12-postgresql-debversion'
     $postgresql_evr_package = 'rh-postgresql12-postgresql-evr'
   } else {
-    $postgresql_debversion_package = 'postgresql-debversion'
     $postgresql_evr_package = 'postgresql-evr'
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,8 +22,6 @@
 #   The oauth key for Candlepin
 # @param candlepin_oauth_secret
 #   The oauth secret for Candlepin
-# @param postgresql_debversion_package
-#   The contextual package name for the PostgreSQL debversion extension
 # @param postgresql_evr_package
 #   The contextual package name for the PostgreSQL EVR extension
 class katello::params (
@@ -34,7 +32,6 @@ class katello::params (
   String[1] $candlepin_oauth_secret = $katello::globals::candlepin_oauth_secret,
   Stdlib::Host $candlepin_host = 'localhost',
   Stdlib::HTTPSUrl $candlepin_url = "https://${candlepin_host}:8443/candlepin",
-  String[1] $postgresql_debversion_package = $katello::globals::postgresql_debversion_package,
   String[1] $postgresql_evr_package = $katello::globals::postgresql_evr_package,
 ) inherits katello::globals {
 }

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -20,12 +20,10 @@ describe 'katello::application' do
         if facts[:operatingsystemmajrelease] == '7'
           it { is_expected.to create_package('tfm-rubygem-katello') }
           it { is_expected.not_to create_package('tfm-rubygem-katello').that_requires('Anchor[katello::candlepin]') }
-          it { is_expected.to create_package('rh-postgresql12-postgresql-debversion') }
           it { is_expected.to create_package('rh-postgresql12-postgresql-evr') }
         else
           it { is_expected.to create_package('rubygem-katello') }
           it { is_expected.not_to create_package('rubygem-katello').that_requires('Anchor[katello::candlepin]') }
-          it { is_expected.to create_package('postgresql-debversion') }
           it { is_expected.to create_package('postgresql-evr') }
         end
 


### PR DESCRIPTION
This reverts commit 6b0c9b4c7374cc6c577642d8fd6c9277b9bcd46a.

Initially this was merged because the support was [needed in Katello](https://github.com/Katello/katello/commit/514770541975012ea85a5780fd67c237cb535e2d). Later this PR was [reverted](https://github.com/Katello/katello/commit/a569779c9d8f623de1fed00c2d8ca0a89bf483d1).