### PR TITLE
Refs #29817 - Implement a resizable hosts_queue pool

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -3,8 +3,12 @@
 # @param rest_client_timeout
 #   Timeout for Katello rest API
 #
+# @param hosts_queue_workers
+#   The number of workers handling the hosts_queue queue.
+#
 class katello::application (
   Integer[0] $rest_client_timeout = 3600,
+  Integer[0] $hosts_queue_workers = 1,
 ) {
   include foreman
   include certs
@@ -64,9 +68,10 @@ class katello::application (
     ssl_content => file('katello/katello-apache-ssl.conf'),
   }
 
-  if $foreman::jobs_manage_service {
-    foreman::dynflow::worker { 'worker-hosts-queue':
-      queues => ['hosts_queue'],
+  if $foreman::dynflow_manage_services {
+    foreman::dynflow::pool { 'worker-hosts-queue':
+      instances => $hosts_queue_workers,
+      queues    => ['hosts_queue'],
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,8 @@
 #
 # $rest_client_timeout:: Timeout for Katello rest API
 #
+# $hosts_queue_workers::   Configures the number of workers handling the hosts_queue queue.
+#
 class katello (
   Optional[String] $candlepin_oauth_key = undef,
   Optional[String] $candlepin_oauth_secret = undef,
@@ -65,6 +67,8 @@ class katello (
   Boolean $candlepin_db_ssl = false,
   Boolean $candlepin_db_ssl_verify = true,
   Boolean $candlepin_manage_db = true,
+
+  Integer[0] $hosts_queue_workers = 1,
 ) {
 
   package { 'katello':
@@ -97,6 +101,7 @@ class katello (
 
   class { 'katello::application':
     rest_client_timeout => $rest_client_timeout,
+    hosts_queue_workers => $hosts_queue_workers,
   }
 
   class { 'katello::qpid':

--- a/metadata.json
+++ b/metadata.json
@@ -34,7 +34,7 @@
     },
     {
       "name": "theforeman/foreman",
-      "version_requirement": ">= 16.0.0 < 17.0.0"
+      "version_requirement": ">= 17.0.0 < 18.0.0"
     }
   ],
   "requirements": [

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -56,9 +56,8 @@ describe 'katello::application' do
             .with_ssl_content(%r{^<LocationMatch /rhsm\|/katello/api>$})
         end
 
-        it do
-          is_expected.to contain_foreman__dynflow__worker('worker-hosts-queue')
-        end
+        it { is_expected.to contain_foreman__dynflow__pool('worker-hosts-queue').with_instances(1) }
+        it { is_expected.to contain_foreman__dynflow__worker('worker-hosts-queue') }
 
         let(:katello_yaml_content) do
           if facts[:operatingsystemmajrelease] == '7'


### PR DESCRIPTION
This uses the new foreman::dynflow::pool defined type which allows users to easily add additional workers or scale them back.

Currently a draft since it's pointing to my branch in the fixtures to allow testing. Blocked on https://github.com/theforeman/puppet-foreman/pull/843.