### PR TITLE
Bump major version to 17

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "katello-katello",
-  "version": "16.0.0",
+  "version": "17.0.0",
   "author": "katello",
   "summary": "Handles deploying and managing a Katello + Foreman server",
   "license": "GPL-3.0+",


### PR DESCRIPTION
There have been breakin changes so it's good to increase the major version. A stable version will be released and master shouldn't be an older version than what's released.