### PR TITLE
Drop inclusion of pulp-vhosts80 with no managed content types

### DIFF
--- a/templates/pulp-apache.conf.erb
+++ b/templates/pulp-apache.conf.erb
@@ -1,7 +1,5 @@
 ### File managed with puppet ###
 
-Include <%= scope['apache::confd_dir'] %>/pulp-vhosts80/*.conf
-
 <Location /pulp>
   <IfModule mod_passenger.c>
     PassengerEnabled off


### PR DESCRIPTION
Follow on for: a0917838fabc8241e3e5e7f678378a2d45cbea54