### PR TITLE
Refs #31878 - Allow external mechanism for qpid SASL

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -30,9 +30,9 @@ class katello::qpid (
 
   contain qpid
 
-  qpid::config::queue { $katello::params::agent_event_queue_name:
+  qpid::config::queue { "${katello::params::agent_event_queue_name} --sasl-mechanism=EXTERNAL":
     ssl_cert => $certs::qpid::client_cert,
     ssl_key  => $certs::qpid::client_key,
-    hostname => $katello::params::qpid_hostname,
+    hostname => "${certs::qpid::hostname}@${katello::params::qpid_hostname}",
   }
 }

--- a/spec/acceptance/qpid_spec.rb
+++ b/spec/acceptance/qpid_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper_acceptance'
+
+describe 'Install Candlepin' do
+  let(:pp) { 'include katello::qpid' }
+
+  it_behaves_like 'a idempotent resource'
+
+  describe service('qpidd') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port('5671') do
+    it { is_expected.to be_listening }
+  end
+
+  describe port('5672') do
+    it { is_expected.to be_listening }
+  end
+end

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -12,7 +12,7 @@ describe 'katello::qpid' do
       end
 
       it do
-        is_expected.to create_qpid__config__queue('katello.agent')
+        is_expected.to create_qpid__config__queue('katello.agent --sasl-mechanism=EXTERNAL')
           .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
           .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
       end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -12,6 +12,12 @@ group { 'foreman':
   ensure => present,
 }
 
+if $facts['os']['release']['major'] == '7' {
+  package { 'epel-release':
+    ensure => installed,
+  }
+}
+
 if $facts['os']['release']['major'] == '8' {
   # https://tickets.puppetlabs.com/browse/PUP-9978
   exec { '/usr/bin/dnf -y module enable pki-core':
@@ -19,5 +25,18 @@ if $facts['os']['release']['major'] == '8' {
 
   package { 'glibc-langpack-en':
     ensure => installed,
+  }
+
+  yumrepo { 'katello_staging':
+    descr    => "katello staging",
+    baseurl  => "http://koji.katello.org/releases/yum/katello-nightly/katello/el8/x86_64/",
+    enabled  => true,
+    gpgcheck => false,
+  }
+
+  package { 'dnf-plugins-core':
+    ensure => installed,
+  } ~>
+  exec { '/usr/bin/dnf config-manager --set-enabled powertools':
   }
 }


### PR DESCRIPTION
On EL8, the SASL enforcement is more pronounced and does not allow anonymous connections when using qpid-stat or qpid-config. We need to specify the mechanism, external for SSL client certificates, and the user, CN of the certificates being used, to call the command. This shows how we can modify this single call we used to do this. The alternative is we invest more in puppet-qpid and add these options directly and then do a release of puppet-qpid.