### PR TITLE
Refs #31878 - Allow external mechanism for qpid SASL

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -31,8 +31,10 @@ class katello::qpid (
   contain qpid
 
   qpid::config::queue { $katello::params::agent_event_queue_name:
-    ssl_cert => $certs::qpid::client_cert,
-    ssl_key  => $certs::qpid::client_key,
-    hostname => $katello::params::qpid_hostname,
+    ssl_cert       => $certs::qpid::client_cert,
+    ssl_key        => $certs::qpid::client_key,
+    hostname       => $katello::params::qpid_hostname,
+    username       => $certs::qpid::hostname,
+    sasl_mechanism => 'EXTERNAL',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "katello/qpid",
-      "version_requirement": ">= 4.5.0 < 7.0.0"
+      "version_requirement": ">= 6.2.0 < 7.0.0"
     },
     {
       "name": "theforeman/foreman",

--- a/spec/acceptance/qpid_spec.rb
+++ b/spec/acceptance/qpid_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper_acceptance'
+
+describe 'Install qpid' do
+  let(:pp) { 'include katello::qpid' }
+
+  it_behaves_like 'a idempotent resource'
+
+  describe service('qpidd') do
+    it { is_expected.to be_running }
+    it { is_expected.to be_enabled }
+  end
+
+  describe port('5671') do
+    it { is_expected.to be_listening }
+  end
+
+  describe port('5672') do
+    it { is_expected.to be_listening }
+  end
+end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -13,10 +13,6 @@ group { 'foreman':
 }
 
 if $facts['os']['release']['major'] == '8' {
-  # https://tickets.puppetlabs.com/browse/PUP-9978
-  exec { '/usr/bin/dnf -y module enable pki-core':
-  }
-
   package { 'glibc-langpack-en':
     ensure => installed,
   }

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -16,4 +16,12 @@ if $facts['os']['release']['major'] == '8' {
   package { 'glibc-langpack-en':
     ensure => installed,
   }
+
+  yumrepo { 'powertools':
+    enabled => true,
+  }
+} elsif $facts['os']['release']['major'] == '7' {
+  package { 'epel-release':
+    ensure => installed,
+  }
 }


### PR DESCRIPTION
This is an alternative to https://github.com/theforeman/puppet-katello/pull/388. The last commit should not be added, but is there to allow this to pass CI.