### PR TITLE
Refs #31878 - Correct qpid dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "katello/qpid",
-      "version_requirement": ">= 6.2.0 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "theforeman/foreman",


### PR DESCRIPTION
In ce98aab5a87dd542eaf649622f0aa7df6207f2d5 the qpid dependency was set to >= 6.2.0 but 6.2.0 was already released. It was just that master still had 6.1.0 which confused me. This corrects the matter and allows the newer version to be used.

Requires https://github.com/theforeman/puppet-qpid/pull/146

Fixes: ce98aab5a87dd542eaf649622f0aa7df6207f2d5