### PR TITLE
Update Limitations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module is designed to setup a full katello server, including candlepin, pul
 
 ## Limitations
 
-* Supports EL7 (RHEL7 / CentOS 7) and EL8 (RHEL8 / CentOS 8)
+* OS Support and other requirements should be checked in the [metadata.json](metadata.json)
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This module is designed to setup a full katello server, including candlepin, pul
 
 ## Limitations
 
-* EL7 (RHEL7 / CentOS 7)
+* Supports EL7 (RHEL7 / CentOS 7) and EL8 (RHEL8 / CentOS 8)
 
 ## Development
 


### PR DESCRIPTION
Update the supported platforms to include RHEL8 as well. Support for this was added with #335 but this change didn't update the README as well.

Closes #397