### PR TITLE
Remove Scientific 8 support from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -61,8 +61,7 @@
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     }
   ]


### PR DESCRIPTION
There is no ScientificLinux 8. The effort was folded into the CentOS project.