### PR TITLE
Refs #32369 - Move content enable flags to params

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -13,10 +13,10 @@
 #   Enable debian content plugin
 #
 class katello::globals(
-  Boolean $enable_yum = true,
-  Boolean $enable_file = true,
-  Boolean $enable_docker = true,
-  Boolean $enable_deb = true,
+  Katello::HieraBoolean $enable_yum = true,
+  Katello::HieraBoolean $enable_file = true,
+  Katello::HieraBoolean $enable_docker = true,
+  Katello::HieraBoolean $enable_deb = true,
 ) {
   # OAUTH settings
   $candlepin_oauth_key = 'katello'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,14 +4,6 @@
 #
 # === Parameters:
 #
-# $enable_yum::         Enable rpm content plugin, including syncing of yum content
-#
-# $enable_file::        Enable generic file content management
-#
-# $enable_docker::      Enable docker content plugin
-#
-# $enable_deb::         Enable debian content plugin
-#
 # === Advanced parameters:
 #
 # $candlepin_oauth_key:: The OAuth key for talking to the candlepin API
@@ -54,11 +46,6 @@ class katello (
   String $qpid_interface = 'lo',
   Stdlib::Host $qpid_hostname = 'localhost',
 
-  Boolean $enable_yum = true,
-  Boolean $enable_file = true,
-  Boolean $enable_docker = true,
-  Boolean $enable_deb = true,
-
   String $candlepin_db_host = 'localhost',
   Optional[Stdlib::Port] $candlepin_db_port = undef,
   String $candlepin_db_name = 'candlepin',
@@ -73,13 +60,6 @@ class katello (
 
   package { 'katello':
     ensure => installed,
-  }
-
-  class { 'katello::globals':
-    enable_yum    => $enable_yum,
-    enable_file   => $enable_file,
-    enable_docker => $enable_docker,
-    enable_deb    => $enable_deb,
   }
 
   class { 'katello::params':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,4 +36,10 @@ class katello::params (
   String[1] $candlepin_client_keypair_group = 'foreman',
   String[1] $postgresql_evr_package = $katello::globals::postgresql_evr_package,
 ) inherits katello::globals {
+
+  $enable_yum = $katello::globals::enable_yum != false
+  $enable_file = $katello::globals::enable_file != false
+  $enable_docker = $katello::globals::enable_docker != false
+  $enable_deb = $katello::globals::enable_deb != false
+
 }

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -280,6 +280,77 @@ describe 'katello::application' do
           it { is_expected.to create_package('rubygem-katello').that_requires('Anchor[katello::candlepin]') }
         end
       end
+
+      context 'with katello::globals parameter as an empty string' do
+        let :pre_condition do
+          <<-EOS
+          class {'katello::globals':
+            enable_deb => '',
+          }
+          #{super()}
+          EOS
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        let(:katello_yaml_content) do
+          if facts[:operatingsystemmajrelease] == '7'
+            [
+              ':katello:',
+              '  :rest_client_timeout: 3600',
+              '  :content_types:',
+              '    :yum: true',
+              '    :file: true',
+              '    :deb: true',
+              '    :puppet: false',
+              '    :docker: true',
+              '    :ostree: false',
+              '  :candlepin:',
+              '    :url: https://localhost:23443/candlepin',
+              '    :oauth_key: "katello"',
+              '    :oauth_secret: "candlepin-secret"',
+              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+              '  :candlepin_events:',
+              '    :ssl_cert_file: /etc/pki/katello/certs/java-client.crt',
+              '    :ssl_key_file: /etc/pki/katello/private/java-client.key',
+              '    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt',
+              '  :agent:',
+              '    :broker_url: amqps://localhost:5671',
+              '    :event_queue_name: katello.agent',
+              '  :katello_applicability: true',
+            ]
+          else
+            [
+              ':katello:',
+              '  :rest_client_timeout: 3600',
+              '  :content_types:',
+              '    :yum: true',
+              '    :file: true',
+              '    :deb: true',
+              '    :puppet: false',
+              '    :docker: true',
+              '    :ostree: false',
+              '  :candlepin:',
+              '    :url: https://localhost:23443/candlepin',
+              '    :oauth_key: "katello"',
+              '    :oauth_secret: "candlepin-secret"',
+              '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+              '  :candlepin_events:',
+              '    :ssl_cert_file: /etc/pki/katello/certs/java-client.crt',
+              '    :ssl_key_file: /etc/pki/katello/private/java-client.key',
+              '    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt',
+              '  :agent:',
+              '    :broker_url: amqps://localhost:5671',
+              '    :event_queue_name: katello.agent',
+              '  :katello_applicability: true',
+            ]
+          end
+        end
+
+        it 'should generate correct katello.yaml' do
+          verify_exact_contents(catalogue, '/etc/foreman/plugins/katello.yaml', katello_yaml_content)
+        end
+      end
     end
   end
 end

--- a/types/hieraboolean.pp
+++ b/types/hieraboolean.pp
@@ -1,0 +1,3 @@
+# @summary A boolean that also accepts empty strings
+# In Hiera the function alias() returns an empty string if the value is undefined.
+type Katello::HieraBoolean = Variant[Boolean, Enum['']]


### PR DESCRIPTION
This moves the content enable flags to the params class and away from
init.pp. This will allow a user to either set these via the globals
class or via hiera.