### PR TITLE
Require tomcat user when declaring certs::candlepin

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -33,6 +33,7 @@ class katello::candlepin (
   class { 'certs::candlepin':
     hostname             => $katello::params::candlepin_host,
     client_keypair_group => $katello::params::candlepin_client_keypair_group,
+    require              => User['tomcat'],
   }
 
   class { 'candlepin':


### PR DESCRIPTION
I am not convinced at all that this is the right solution, but it helps demonstrate the problem that the puppet-katello acceptance tests now face as a result of merging https://github.com/theforeman/puppet-certs/pull/320.

puppet-katello master acceptance test currently fails like this:

```
 Notice: Compiled catalog for centos7-64.example.com in environment production in 0.61 seconds
  Info: Applying configuration version '1619036374'
  Notice: /Stage[main]/Certs::Install/Package[katello-certs-tools]/ensure: created
  Notice: /Stage[main]/Certs::Config/File[/etc/pki/katello]/ensure: created
  Notice: /Stage[main]/Certs::Config/File[/etc/pki/katello/certs]/ensure: created
  Notice: /Stage[main]/Certs::Config/File[/etc/pki/katello/private]/ensure: created
  Notice: /Stage[main]/Certs::Ca/File[/etc/pki/katello/private/katello-default-ca.pwd]/ensure: defined content as '{md5}5cb4477f973a8cda18885a84f6a1efb0'
  Notice: /Stage[main]/Certs::Ca/Ca[katello-default-ca]/ensure: created
  Notice: /Stage[main]/Certs::Ca/Ca[katello-server-ca]/ensure: created
  Notice: /Stage[main]/Certs::Ca/File[/root/ssl-build/KATELLO-TRUSTED-SSL-CERT]/ensure: created
  Notice: /Stage[main]/Certs::Ca/Pubkey[/etc/pki/katello/certs/katello-default-ca.crt]/ensure: created
  Notice: /Stage[main]/Certs::Ca/Pubkey[/etc/pki/katello/certs/katello-default-ca-stripped.crt]/ensure: created
  Notice: /Stage[main]/Certs::Ca/Pubkey[/etc/pki/katello/certs/katello-server-ca.crt]/ensure: created
  Notice: /Stage[main]/Certs::Ca/Privkey[/etc/pki/katello/private/katello-default-ca.key]/ensure: created
  Notice: /Stage[main]/Certs::Ca/File[/etc/pki/katello/private/katello-default-ca.key]/mode: mode changed '0400' to '0440'
  Info: Class[Certs]: Scheduling refresh of Class[Candlepin]
  Notice: /Stage[main]/Certs::Candlepin/Cert[java-client]/ensure: created
  Notice: /Stage[main]/Certs::Candlepin/Cert[localhost-tomcat]/ensure: created
  Error: Could not set 'file' on ensure: Could not find group tomcat (file: /etc/puppetlabs/code/environments/production/modules/certs/manifests/candlepin.pp, line: 133)
  Error: Could not set 'file' on ensure: Could not find group tomcat (file: /etc/puppetlabs/code/environments/production/modules/certs/manifests/candlepin.pp, line: 133)
  Wrapped exception:
  Could not find group tomcat
  Error: /Stage[main]/Certs::Candlepin/File[/etc/pki/katello/truststore_password-file]/ensure: change from 'absent' to 'file' failed: Could not set 'file' on ensure: Could not find group tomcat (file: /etc/puppetlabs/code/environments/production/modules/certs/manifests/candlepin.pp, line: 133)
```

I feel like the merging of https://github.com/theforeman/puppet-certs/pull/320 more so revealed some fragileness in how we handle the certificates. As most of the certificate class are intended to be created *before* the services using them but often rely upon users and groups managed by the puppet modules that the certificates are being generated for. I don't want to get too deep down that design rabbit hole in this PR as we do need to fix this issue to get the tests passing again.

In a scenario where foreman-installer is used, this problem is avoided because we always installing the Candlepin RPM which pulls in the tomcat RPM and thus creates the tomcat user before this code is encountered.

To recap, let's come up with the right short term solution whether here in this class or in puppet-certs directly and then let's do a separate design discussion if others agree we should re-examine that certificate/user/group relationship and who owns managing the certificate files. (I am reminded of some work I started here -- https://github.com/theforeman/puppet-candlepin/pull/159)