### PR TITLE
Refs #32381: Add function to determine the Artemis user string dynamically from th…

### DIFF
--- a/lib/puppet/functions/katello/certificate_subject.rb
+++ b/lib/puppet/functions/katello/certificate_subject.rb
@@ -1,0 +1,23 @@
+# @summary
+#   Extracts a certificate's subject in RFC2253 form
+#
+# @example How to extract a certificate's subject
+#   $cert_subject = katello::certificate_subject($path_to_certificate)
+#
+Puppet::Functions.create_function(:'katello::certificate_subject') do
+  # @param certificate_path
+  #
+  # @return [String]
+  dispatch :certificate_subject do
+    param 'Stdlib::Absolutepath', :certificate_path
+  end
+
+  def certificate_subject(certificate_path)
+    begin
+      cert = OpenSSL::X509::Certificate.new(File.read(certificate_path))
+      cert.subject.to_s(OpenSSL::X509::Name::RFC2253)
+    rescue OpenSSL::X509::CertificateError, Errno::ENOENT
+      nil
+    end
+  end
+end

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -35,6 +35,8 @@ class katello::candlepin (
     client_keypair_group => $katello::params::candlepin_client_keypair_group,
   }
 
+  $artemis_client_dn = katello::certificate_subject($certs::candlepin::client_cert)
+
   class { 'candlepin':
     host                         => $katello::params::candlepin_host,
     ssl_port                     => $katello::params::candlepin_port,
@@ -47,7 +49,7 @@ class katello::candlepin (
     keystore_password            => $certs::candlepin::keystore_password,
     truststore_file              => $certs::candlepin::truststore,
     truststore_password          => $certs::candlepin::truststore_password,
-    artemis_client_dn            => $certs::candlepin::artemis_client_dn,
+    artemis_client_dn            => $artemis_client_dn,
     java_home                    => '/usr/lib/jvm/jre-11',
     java_package                 => 'java-11-openjdk',
     enable_basic_auth            => false,

--- a/spec/functions/katello_certificate_subject_spec.rb
+++ b/spec/functions/katello_certificate_subject_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe 'katello::certificate_subject' do
+  let(:test_cert) do
+  <<-CERT
+-----BEGIN CERTIFICATE-----
+MIIC+TCCAeGgAwIBAgIUetO+zvwJ4nLNrxe9lcrT4h0noCMwDQYJKoZIhvcNAQEL
+BQAwHjEcMBoGA1UEAwwTVGVzdCBTZWxmLVNpZ25lZCBDQTAeFw0yMDExMTgwMjMw
+NDNaFw0zMDExMTYwMjMwNDNaMB4xHDAaBgNVBAMME2ZvcmVtYW4uZXhhbXBsZS5j
+b20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDcEtPd1uKX0hct7+qe
+gOEy72VB93cBGuEJis6yD7uJfdjnbBtiFwkxUqmQlsDmUsqcuh6106yDkaW6tyzT
+I6R0Xx8OJkT4bxOsgkr3xqZSrAQJvn/NmV4j6egckJlgYnSbkrOFvy5iO1A/Dc/m
+OrC6TJVGe/YvMCU6IYPU1f/acNucRZGopa7yfhyTd8nzArq1BCSrjqtCl8m9NPJZ
+IP8+06wQ6MCjyd+kjnm+Tq/P+mKEsXVDBQCQAyWFpZdUcu4zbL+UV2+O7QUtndEh
+k2nf4w3Rx70XvMwagfo3hE5cJ8rNXEynphhDzdJqzRDpPYItZauMDxmK+4oHOn0g
+90t5AgMBAAGjLzAtMAsGA1UdDwQEAwIFIDAeBgNVHREEFzAVghNmb3JlbWFuLmV4
+YW1wbGUuY29tMA0GCSqGSIb3DQEBCwUAA4IBAQBlIEA2CfZIa8LtUYlDwa5v+5Wf
+1ktmYTRtgEI+922T/eTB8uH1//VxpfK5ynljao7SNVcX+74Q+YH/4Ci4OfZvE5vA
+1IJXog5bfE4mVc1qXhH7TokBQx1L6vtUh9OaTGpBAVnS3J5jLw6+Tdi9FOeZdKHZ
+FvMnyZ7MQ6VjbLZsTy49o87Nstqkle48ivwSFrDU1cDN+6S/DUdHQnh8XtPB1PMh
+7WCxGGtzmw5s5SxBkyY/buGDr+kx52yULl6ZrnJD6PfR30X+8G3ltvmaCQllYadX
+eprUs5H2WDnTUUE78+cf1JK29Zs9it/l4t2uLc5Z94oXosFLkTKw6ZSB3X9J
+-----END CERTIFICATE-----
+  CERT
+  end
+
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should return a certificate subject in RFC2253 format' do
+    file = class_double("File")
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with("/tmp/client_cert.crt").and_return(test_cert)
+
+    is_expected.to run.with_params('/tmp/client_cert.crt').and_return("CN=foreman.example.com")
+  end
+
+  it 'should handle a bad certificate' do
+    file = class_double("File")
+    allow(File).to receive(:read).and_call_original
+    allow(File).to receive(:read).with("/tmp/client_cert.crt").and_return('aab32433adfad')
+
+    is_expected.to run.with_params('/tmp/client_cert.crt').and_return(nil)
+  end
+
+  it 'should handle a non-existent file' do
+    is_expected.to run.with_params('/tmp/client_cert.crt').and_return(nil)
+  end
+end


### PR DESCRIPTION
…e certificate

This suffers from this issue: https://github.com/theforeman/puppet-katello/pull/404
This is not intended for the upcoming Foreman 2.5 release

This value is currently declared in puppet-certs in a hard-coded manner (https://github.com/theforeman/puppet-certs/blob/master/manifests/candlepin.pp#L29). This is a fragile method. By deriving this directly from the certificate used, we can instead more safely modify and change the certificates.

This is the first part of a change I intend to make that moves away from using `certs::candlepin::client_cert` and moves instead to using `certs::foreman::client_cert` which will help reduce the number of certificates generated and the number of different certificates configured for use of inside Foreman. This aims towards that single set of client certificates for Foreman used to talk to our different backends goal.