### PR TITLE
Fixes #32383: Do not set Pulp client certificates

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -18,18 +18,6 @@ class katello::application (
   include certs::pulp_client
   include katello::params
 
-  foreman_config_entry { 'pulp_client_cert':
-    value          => $certs::pulp_client::client_cert,
-    ignore_missing => false,
-    require        => [Class['certs::pulp_client'], Foreman::Rake['db:seed']],
-  }
-
-  foreman_config_entry { 'pulp_client_key':
-    value          => $certs::pulp_client::client_key,
-    ignore_missing => false,
-    require        => [Class['certs::pulp_client'], Foreman::Rake['db:seed']],
-  }
-
   include foreman::plugin::tasks
 
   Class['certs', 'certs::ca', 'certs::apache'] ~> Class['apache::service']

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -28,18 +28,6 @@ describe 'katello::application' do
         end
 
         it do
-          is_expected.to create_foreman_config_entry('pulp_client_cert')
-            .with_value('/etc/pki/katello/certs/pulp-client.crt')
-            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-        end
-
-        it do
-          is_expected.to create_foreman_config_entry('pulp_client_key')
-            .with_value('/etc/pki/katello/private/pulp-client.key')
-            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-        end
-
-        it do
           is_expected.to contain_service('httpd')
             .that_subscribes_to(['Class[Certs::Apache]', 'Class[Certs::Ca]'])
         end


### PR DESCRIPTION
Rely on the default setting from the application for Pulp client
certificates which will be the Foreman client certificates.