### PR TITLE
Refs #32511 - Rename certs::qpid::nss_db_password_path

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -21,7 +21,7 @@ class katello::qpid (
     $_qpid_ensure = 'present'
     $ssl = true
     $ssl_cert_db = $certs::qpid::nss_db_dir
-    $ssl_cert_password_file = $certs::qpid::nss_db_password_file
+    $ssl_cert_password_file = $certs::qpid::nss_db_password_path
     $ssl_cert_name = $certs::qpid::nss_cert_name
 
     Class['certs', 'certs::qpid'] ~> Class['qpid']

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 11.0.0 < 13.0.0"
+      "version_requirement": ">= 12.1.0 < 13.0.0"
     },
     {
       "name": "katello/qpid",


### PR DESCRIPTION
Requires a merge of puppet-certs #344 and subsequent
release of puppet-cers v12.1.0