### PR TITLE
Manage the EVR extension

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -61,8 +61,13 @@ class katello::application (
   }
 
   if $manage_db {
-    package { $postgresql_evr_package:
-      ensure => installed,
+    postgresql::server::extension { 'evr':
+      database     => $foreman::database::postgresql::dbname,
+      package_name => $postgresql_evr_package,
+    }
+
+    if $foreman::db_manage_rake {
+      Postgresql::Server::Extension['evr'] ~> Foreman::Rake['db:migrate']
     }
   }
 


### PR DESCRIPTION
The PostgreSQL can manage an extension and ensure it's loaded. This correctly chains all dependencies where previously it was based on luck.

Currently untested, but it came up in a meeting.