### PR TITLE
Ensure Artemis client cert exists before tomcat cert-users.properties

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -65,5 +65,7 @@ class katello::candlepin (
   } ->
   anchor { 'katello::candlepin': } # lint:ignore:anchor_resource
 
+  File[$certs::candlepin::client_cert] -> File["${::candlepin::catalina_home}/conf/cert-users.properties"]
+
   contain candlepin
 }


### PR DESCRIPTION
The Artemis client DN is calculated as a Deferred object at manifest
apply time. The client certificate needs to exist on disk before
performing this calculation or else the cert-users.properties
file can end up with a blank entry.