### PR TITLE
Use Foreman client certificates to setup qpid queues

### DIFF
--- a/manifests/qpid.pp
+++ b/manifests/qpid.pp
@@ -48,9 +48,11 @@ class katello::qpid (
   contain qpid
 
   if $katello::params::enable_katello_agent {
+    include certs::foreman
+
     qpid::config::queue { $katello::params::agent_event_queue_name:
-      ssl_cert       => $certs::qpid::client_cert,
-      ssl_key        => $certs::qpid::client_key,
+      ssl_cert       => $certs::foreman::client_cert,
+      ssl_key        => $certs::foreman::client_key,
       hostname       => $katello::params::qpid_hostname,
       username       => $certs::qpid::hostname,
       sasl_mechanism => 'EXTERNAL',

--- a/spec/classes/qpid_spec.rb
+++ b/spec/classes/qpid_spec.rb
@@ -54,8 +54,8 @@ describe 'katello::qpid' do
 
         it do
           is_expected.to create_qpid__config__queue('katello.agent')
-            .with_ssl_cert('/etc/pki/katello/certs/foo.example.com-qpid-broker.crt')
-            .with_ssl_key('/etc/pki/katello/private/foo.example.com-qpid-broker.key')
+            .with_ssl_cert('/etc/foreman/client_cert.pem')
+            .with_ssl_key('/etc/foreman/client_key.pem')
         end
       end
 


### PR DESCRIPTION
Katello uses the Foreman client certificates to talk to Qpid when
katello-agent support is enabled, the same should be used when
setting up Qpid queues and exchanges and not the server certificates
that are intended to be used by Qpid itself.