### PR TITLE
Fixes #33830 - Drop content type settings

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -37,11 +37,6 @@ class katello::application (
   # Used in katello.yaml.erb
   $agent_broker_url = $katello::params::qpid_url
   $agent_event_queue_name = $katello::params::agent_event_queue_name
-  $enable_yum = $katello::params::enable_yum
-  $enable_file = $katello::params::enable_file
-  $enable_docker = $katello::params::enable_docker
-  $enable_deb = $katello::params::enable_deb
-  $enable_ansible_collection = $katello::params::enable_ansible_collection
   $enable_katello_agent = $katello::params::enable_katello_agent
   $candlepin_url = $katello::params::candlepin_url
   $candlepin_oauth_key = $katello::params::candlepin_oauth_key

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,28 +1,9 @@
 # @summary Katello Default Params
 #
-# @param enable_yum
-#   Enable rpm content plugin, including syncing of yum content
-#
-# @param enable_file
-#   Enable generic file content management
-#
-# @param enable_docker
-#   Enable docker content plugin
-#
-# @param enable_deb
-#   Enable debian content plugin
-#
-# @param enable_ansible_collection
-#   Enable ansible collection content plugin
 # @param enable_katello_agent
 #   Set to true to setup Qpid and katello-agent infrastructure.
 #
 class katello::globals(
-  Katello::HieraBoolean $enable_yum = true,
-  Katello::HieraBoolean $enable_file = true,
-  Katello::HieraBoolean $enable_docker = true,
-  Katello::HieraBoolean $enable_deb = true,
-  Katello::HieraBoolean $enable_ansible_collection = true,
   Katello::HieraBoolean $enable_katello_agent = false,
 ) {
   # OAUTH settings

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,11 +37,6 @@ class katello::params (
   String[1] $postgresql_evr_package = $katello::globals::postgresql_evr_package,
 ) inherits katello::globals {
 
-  $enable_yum = $katello::globals::enable_yum != false
-  $enable_file = $katello::globals::enable_file != false
-  $enable_docker = $katello::globals::enable_docker != false
-  $enable_deb = $katello::globals::enable_deb != false
-  $enable_ansible_collection = $katello::globals::enable_ansible_collection != false
   $enable_katello_agent = $katello::globals::enable_katello_agent != false
 
 }

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -63,14 +63,6 @@ describe 'katello::application' do
           [
             ':katello:',
             '  :rest_client_timeout: 3600',
-            '  :content_types:',
-            '    :yum: true',
-            '    :file: true',
-            '    :deb: true',
-            '    :puppet: false',
-            '    :docker: true',
-            '    :ansible_collection: true',
-            '    :ostree: false',
             '  :candlepin:',
             '    :url: https://localhost:23443/candlepin',
             '    :oauth_key: "katello"',
@@ -126,7 +118,7 @@ describe 'katello::application' do
         let :pre_condition do
           <<-EOS
           class {'katello::globals':
-            enable_deb => false,
+            enable_katello_agent => true,
           }
           #{super()}
           EOS
@@ -138,14 +130,6 @@ describe 'katello::application' do
           [
             ':katello:',
             '  :rest_client_timeout: 3600',
-            '  :content_types:',
-            '    :yum: true',
-            '    :file: true',
-            '    :deb: false',
-            '    :puppet: false',
-            '    :docker: true',
-            '    :ansible_collection: true',
-            '    :ostree: false',
             '  :candlepin:',
             '    :url: https://localhost:23443/candlepin',
             '    :oauth_key: "katello"',
@@ -156,7 +140,9 @@ describe 'katello::application' do
             '    :ssl_key_file: /etc/foreman/client_key.pem',
             '    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt',
             '  :agent:',
-            '    :enabled: false',
+            '    :enabled: true',
+            '    :broker_url: amqps://localhost:5671',
+            '    :event_queue_name: katello.agent',
           ]
         end
 
@@ -181,23 +167,15 @@ describe 'katello::application' do
         let :pre_condition do
           <<-EOS
           class {'katello::globals':
-            enable_deb => '',
+            enable_katello_agent => '',
           }
-          #{super()}
           EOS
         end
 
         it { is_expected.to compile.with_all_deps }
 
-        let(:katello_yaml_content) do
-          [
-            '  :content_types:',
-            '    :deb: true',
-          ]
-        end
-
         it 'should generate correct katello.yaml' do
-          verify_contents(catalogue, '/etc/foreman/plugins/katello.yaml', katello_yaml_content)
+          is_expected.to contain_file('/etc/foreman/plugins/katello.yaml').with_content(%r{:enabled: true})
         end
       end
 

--- a/templates/katello.yaml.erb
+++ b/templates/katello.yaml.erb
@@ -4,15 +4,6 @@
 :katello:
   :rest_client_timeout: <%= @rest_client_timeout %>
 
-  :content_types:
-    :file: <%= @enable_file %>
-    :yum: <%= @enable_yum %>
-    :deb: <%= @enable_deb %>
-    :puppet: false
-    :docker: <%= @enable_docker %>
-    :ansible_collection: <%= @enable_ansible_collection %>
-    :ostree: false
-
   :candlepin:
     :url: <%= @candlepin_url %>
     :oauth_key: "<%= @candlepin_oauth_key %>"


### PR DESCRIPTION
Since Katello 4.2 these are no longer needed and determined dynamically.