### PR TITLE
Configure Candlepin with unencrypted CA key

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -20,7 +20,7 @@ fixtures:
       repo: 'https://github.com/puppetlabs/puppetlabs-selinux_core'
       puppet_version: '>= 6.0.0'
     stdlib:        "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    systemd:       "https://github.com/camptocamp/puppet-systemd.git"
+    systemd:       "https://github.com/voxpupuli/puppet-systemd.git"
     yumrepo_core:
       repo: 'https://github.com/puppetlabs/puppetlabs-yumrepo_core'
       puppet_version: '>= 6.0.0'

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -43,7 +43,6 @@ class katello::candlepin (
     oauth_secret                 => $katello::params::candlepin_oauth_secret,
     ca_key                       => $certs::candlepin::ca_key,
     ca_cert                      => $certs::candlepin::ca_cert,
-    ca_key_password              => $certs::ca_key_password,
     keystore_file                => $certs::candlepin::keystore,
     keystore_password            => $certs::candlepin::keystore_password,
     truststore_file              => $certs::candlepin::truststore,

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "katello/certs",
-      "version_requirement": ">= 11.0.0 < 15.0.0"
+      "version_requirement": ">= 15.0.0 < 16.0.0"
     },
     {
       "name": "katello/qpid",


### PR DESCRIPTION
This reverts commit bda1511b88b7954230a0e3bb1a2a71c5b6920e5e.


See https://github.com/theforeman/puppet-certs/pull/386

Candlepin cannot start when a encrypted key is generated using genpkey or on a FIPS enabled machine. Therefore, we should revert to handing Candlepin an unencrypted key.