### PR TITLE
Fixes #35005: Drop setting Pulp client certificate settings

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -15,20 +15,7 @@ class katello::application (
   include certs::apache
   include certs::candlepin
   include certs::foreman
-  include certs::pulp_client
   include katello::params
-
-  foreman_config_entry { 'pulp_client_cert':
-    value          => $certs::pulp_client::client_cert,
-    ignore_missing => false,
-    require        => [Class['certs::pulp_client'], Foreman::Rake['db:seed']],
-  }
-
-  foreman_config_entry { 'pulp_client_key':
-    value          => $certs::pulp_client::client_key,
-    ignore_missing => false,
-    require        => [Class['certs::pulp_client'], Foreman::Rake['db:seed']],
-  }
 
   include foreman::plugin::tasks
 

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -28,18 +28,6 @@ describe 'katello::application' do
         end
 
         it do
-          is_expected.to create_foreman_config_entry('pulp_client_cert')
-            .with_value('/etc/pki/katello/certs/pulp-client.crt')
-            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-        end
-
-        it do
-          is_expected.to create_foreman_config_entry('pulp_client_key')
-            .with_value('/etc/pki/katello/private/pulp-client.key')
-            .that_requires(['Class[Certs::Pulp_client]', 'Foreman::Rake[db:seed]'])
-        end
-
-        it do
           is_expected.to contain_service('httpd')
             .that_subscribes_to(['Class[Certs::Apache]', 'Class[Certs::Ca]'])
         end


### PR DESCRIPTION
These settings were introduced with Pulp 2 and carried over to Pulp
3 before we introduced client authentication support in smart_proxy_pulp.
The support for using Foreman client certificates to talk to Pulp 3 was
introduced in Foreman 3.0. This is now safe to drop.