### PR TITLE
Calculate the client DN for Artemis, ignoring empty values

### DIFF
--- a/lib/puppet/functions/katello/build_dn.rb
+++ b/lib/puppet/functions/katello/build_dn.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'yaml'
+# @summary
+#   Convert an array of attribute pairs to a DN string, ignoring empty values
+#
+# @example Pass a set of
+#   $client_dn = katello::build_dn([['CN', 'foo.example.com'], ['O', 'my_org']])
+Puppet::Functions.create_function(:'katello::build_dn') do
+  # @param options
+  #
+  # @return String
+  dispatch :build_dn do
+    param 'Array', :options
+  end
+
+  def build_dn(options)
+    dn = ''
+
+    options.each_with_index do |value, index|
+      next if value[1].nil?
+      dn += "#{options[index][0]}=#{value[1]}"
+      dn += ', ' unless index == (options.length - 1)
+    end
+
+    dn
+  end
+end

--- a/lib/puppet/functions/katello/build_dn.rb
+++ b/lib/puppet/functions/katello/build_dn.rb
@@ -8,21 +8,12 @@ require 'yaml'
 #   $client_dn = katello::build_dn([['CN', 'foo.example.com'], ['O', 'my_org']])
 Puppet::Functions.create_function(:'katello::build_dn') do
   # @param options
-  #
-  # @return String
   dispatch :build_dn do
-    param 'Array', :options
+    param 'Array[Tuple[String[1], Optional[String[1]]]]', :options
+    return_type 'String'
   end
 
   def build_dn(options)
-    dn = ''
-
-    options.each_with_index do |value, index|
-      next if value[1].nil?
-      dn += "#{options[index][0]}=#{value[1]}"
-      dn += ', ' unless index == (options.length - 1)
-    end
-
-    dn
+    options.select { |_key, value| value }.map { |key, value| "#{key}=#{value}" }.join(', ')
   end
 end

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -13,7 +13,6 @@ class katello::application (
   include foreman
   include certs
   include certs::apache
-  include certs::candlepin
   include certs::foreman
   include katello::params
 
@@ -32,10 +31,13 @@ class katello::application (
   $candlepin_oauth_key = $katello::params::candlepin_oauth_key
   $candlepin_oauth_secret = $katello::params::candlepin_oauth_secret
   $candlepin_ca_cert = $certs::ca_cert
-  $candlepin_events_ssl_cert = $certs::candlepin::client_cert
-  $candlepin_events_ssl_key = $certs::candlepin::client_key
+  $candlepin_events_ssl_cert = $certs::foreman::client_cert
+  $candlepin_events_ssl_key = $certs::foreman::client_key
   $postgresql_evr_package = $katello::params::postgresql_evr_package
   $manage_db = $foreman::db_manage
+
+  # Used in Candlepin
+  $artemis_client_dn = katello::build_dn([['CN', $certs::foreman::hostname], ['OU', $certs::foreman::org_unit], ['O', $certs::foreman::org], ['ST', $certs::foreman::state], ['C', $certs::foreman::country]])
 
   # Katello database seeding needs candlepin
   Anchor <| title == 'katello::repo' or title ==  'katello::candlepin' |> ->

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -31,7 +31,10 @@ class katello::candlepin (
   Boolean $manage_db = true,
 ) {
   include certs
+  include certs::foreman
   include katello::params
+
+  $client_dn = katello::build_dn([['CN', $certs::foreman::hostname], ['OU', $certs::foreman::org_unit], ['O', $certs::foreman::org], ['ST', $certs::foreman::state], ['C', $certs::foreman::country]])
 
   class { 'certs::candlepin':
     hostname             => $katello::params::candlepin_host,
@@ -50,7 +53,7 @@ class katello::candlepin (
     keystore_password            => $certs::candlepin::keystore_password,
     truststore_file              => $certs::candlepin::truststore,
     truststore_password          => $certs::candlepin::truststore_password,
-    artemis_client_dn            => $certs::candlepin::artemis_client_dn,
+    artemis_client_dn            => $client_dn,
     java_home                    => '/usr/lib/jvm/jre-11',
     java_package                 => 'java-11-openjdk',
     enable_basic_auth            => false,

--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -19,6 +19,9 @@
 #   The CA certificate to verify the SSL connection to the database with
 # @param manage_db
 #   Whether to manage the database. Set this to false when using a remote database
+# @param artemis_client_dn
+#   The Distinguished Name of the client certificate that's allowed to access
+#   Artemis. It should still be signed by the correct Certificate Authority.
 class katello::candlepin (
   Stdlib::Host $db_host = 'localhost',
   Optional[Stdlib::Port] $db_port = undef,
@@ -29,12 +32,10 @@ class katello::candlepin (
   Boolean $db_ssl_verify = true,
   Optional[Stdlib::Absolutepath] $db_ssl_ca = undef,
   Boolean $manage_db = true,
+  Variant[Undef, Deferred, String[1]] $artemis_client_dn = undef,
 ) {
   include certs
-  include certs::foreman
   include katello::params
-
-  $client_dn = katello::build_dn([['CN', $certs::foreman::hostname], ['OU', $certs::foreman::org_unit], ['O', $certs::foreman::org], ['ST', $certs::foreman::state], ['C', $certs::foreman::country]])
 
   class { 'certs::candlepin':
     hostname             => $katello::params::candlepin_host,
@@ -53,7 +54,7 @@ class katello::candlepin (
     keystore_password            => $certs::candlepin::keystore_password,
     truststore_file              => $certs::candlepin::truststore,
     truststore_password          => $certs::candlepin::truststore_password,
-    artemis_client_dn            => $client_dn,
+    artemis_client_dn            => $artemis_client_dn,
     java_home                    => '/usr/lib/jvm/jre-11',
     java_package                 => 'java-11-openjdk',
     enable_basic_auth            => false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,21 +70,22 @@ class katello (
     qpid_hostname          => $qpid_hostname,
   }
 
-  class { 'katello::candlepin':
-    db_host       => $candlepin_db_host,
-    db_port       => $candlepin_db_port,
-    db_name       => $candlepin_db_name,
-    db_user       => $candlepin_db_user,
-    db_password   => $candlepin_db_password,
-    db_ssl        => $candlepin_db_ssl,
-    db_ssl_verify => $candlepin_db_ssl_verify,
-    db_ssl_ca     => $candlepin_db_ssl_ca,
-    manage_db     => $candlepin_manage_db,
-  }
-
   class { 'katello::application':
     rest_client_timeout => $rest_client_timeout,
     hosts_queue_workers => $hosts_queue_workers,
+  }
+
+  class { 'katello::candlepin':
+    db_host           => $candlepin_db_host,
+    db_port           => $candlepin_db_port,
+    db_name           => $candlepin_db_name,
+    db_user           => $candlepin_db_user,
+    db_password       => $candlepin_db_password,
+    db_ssl            => $candlepin_db_ssl,
+    db_ssl_verify     => $candlepin_db_ssl_verify,
+    db_ssl_ca         => $candlepin_db_ssl_ca,
+    manage_db         => $candlepin_manage_db,
+    artemis_client_dn => $katello::application::artemis_client_dn,
   }
 
   class { 'katello::qpid':

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -19,4 +19,12 @@ describe 'Install Candlepin' do
   describe command('curl -k -s -o /dev/null -w \'%{http_code}\' https://localhost:23443/candlepin/status') do
     its(:stdout) { should eq "200" }
   end
+
+  describe file("/usr/share/tomcat/conf/cert-users.properties") do
+    it { should be_file }
+    it { should be_mode 640 }
+    it { should be_owned_by 'tomcat' }
+    it { should be_grouped_into 'tomcat' }
+    its(:content) { should eq("katelloUser=CN=#{fact('fqdn')}, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US\n") }
+  end
 end

--- a/spec/acceptance/candlepin_spec.rb
+++ b/spec/acceptance/candlepin_spec.rb
@@ -25,6 +25,6 @@ describe 'Install Candlepin' do
     it { should be_mode 640 }
     it { should be_owned_by 'tomcat' }
     it { should be_grouped_into 'tomcat' }
-    its(:content) { should eq("katelloUser=CN=#{fact('fqdn')}, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US\n") }
+    its(:content) { should eq("katelloUser=CN=ActiveMQ Artemis Client, OU=Artemis, O=ActiveMQ, L=AMQ, ST=AMQ, C=AMQ\n") }
   end
 end

--- a/spec/acceptance/katello_spec.rb
+++ b/spec/acceptance/katello_spec.rb
@@ -40,4 +40,8 @@ describe 'Scenario: install katello' do
   describe command('hammer --version') do
     its(:stdout) { is_expected.to match(/^hammer/) }
   end
+
+  describe file("/usr/share/tomcat/conf/cert-users.properties") do
+    its(:content) { should eq("katelloUser=CN=#{fact('fqdn')}, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US\n") }
+  end
 end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -5,10 +5,10 @@ describe 'katello::candlepin' do
     context "on #{os}" do
       let (:facts) { facts }
 
-      context 'with default parameters' do
+      describe 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to create_class('candlepin') }
+        it { is_expected.to contain_class('candlepin').with_artemis_client_dn('CN=foo.example.com, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US') }
       end
     end
   end

--- a/spec/classes/candlepin_spec.rb
+++ b/spec/classes/candlepin_spec.rb
@@ -5,10 +5,10 @@ describe 'katello::candlepin' do
     context "on #{os}" do
       let (:facts) { facts }
 
-      describe 'with default parameters' do
+      context 'with default parameters' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('certs::candlepin').that_notifies('Service[tomcat]') }
-        it { is_expected.to contain_class('candlepin').with_artemis_client_dn('CN=foo.example.com, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US') }
+        it { is_expected.to create_class('candlepin') }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,7 +6,7 @@ describe 'katello' do
       let(:facts) { facts }
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to contain_class('katello::candlepin') }
+      it { is_expected.to contain_class('katello::candlepin').with_artemis_client_dn('CN=foo.example.com, OU=PUPPET, O=FOREMAN, ST=North Carolina, C=US') }
       it { is_expected.to contain_class('katello::application') }
       it { is_expected.to contain_class('katello::qpid') }
       it { is_expected.to contain_package('rubygem-katello').that_requires('Class[candlepin]') }

--- a/spec/functions/katello_build_dn_spec.rb
+++ b/spec/functions/katello_build_dn_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'katello::build_dn' do
+  it 'should exist' do
+    is_expected.not_to eq(nil)
+  end
+
+  it 'should compute dn' do
+    is_expected.to run.with_params([['a', 1], ['b', 2]]).and_return("a=1, b=2")
+  end
+
+  it 'should compute dn and ignore empty values' do
+    is_expected.to run.with_params([['a', ], ['b', 2]]).and_return("b=2")
+  end
+end

--- a/spec/functions/katello_build_dn_spec.rb
+++ b/spec/functions/katello_build_dn_spec.rb
@@ -6,10 +6,10 @@ describe 'katello::build_dn' do
   end
 
   it 'should compute dn' do
-    is_expected.to run.with_params([['a', 1], ['b', 2]]).and_return("a=1, b=2")
+    is_expected.to run.with_params([['a', '1'], ['b', '2']]).and_return("a=1, b=2")
   end
 
   it 'should compute dn and ignore empty values' do
-    is_expected.to run.with_params([['a', ], ['b', 2]]).and_return("b=2")
+    is_expected.to run.with_params([['a', nil], ['b', '2']]).and_return("b=2")
   end
 end


### PR DESCRIPTION
Moving the computation of the Artemis client DN into this class
instead of relying on the value provided directly by classes in
puppet-certs aims to solve two problems:

 1) Testing at all levels of the value of the client DN
 2) Adding a function to calculate the DN based on a set of values and
    ignoring any empty values which do not end up in the actual certificate

Additionally this removes the layers of indirection `certs::candlepin::artemis_client_dn` which pointed `certs::foreman::client_dn` and moves the calculation closer to the input as this class serves to bring another of items together to properly configure Candlepin/Artemis/Tomcat.

This aims to solve a reported [BZ from Satellite](https://bugzilla.redhat.com/show_bug.cgi?id=1964037) where if a user customizes parts of the certificate creation process, the statically calculated client DN breaks and the Artemis connection breaks. By ignoring empty values the right DN gets provided.

Somewhere in the future, there is a path to eventually calculate this directly from the certificate and avoid even more ambiguity -- my attempts at this previously have proved difficult.