### PR TITLE
Allow but filter out empty strings in build_dn

### DIFF
--- a/lib/puppet/functions/katello/build_dn.rb
+++ b/lib/puppet/functions/katello/build_dn.rb
@@ -9,11 +9,12 @@ require 'yaml'
 Puppet::Functions.create_function(:'katello::build_dn') do
   # @param options
   dispatch :build_dn do
-    param 'Array[Tuple[String[1], Optional[String[1]]]]', :options
+    param 'Array[Tuple[String[1], Optional[String]]]', :options
     return_type 'String'
   end
 
   def build_dn(options)
-    options.select { |_key, value| value }.map { |key, value| "#{key}=#{value}" }.join(', ')
+    options_with_values = options.select { |_key, value| !value.nil? && value != '' }
+    options_with_values.map { |key, value| "#{key}=#{value}" }.join(', ')
   end
 end

--- a/spec/functions/katello_build_dn_spec.rb
+++ b/spec/functions/katello_build_dn_spec.rb
@@ -12,4 +12,8 @@ describe 'katello::build_dn' do
   it 'should compute dn and ignore empty values' do
     is_expected.to run.with_params([['a', nil], ['b', '2']]).and_return("b=2")
   end
+
+  it 'should ignore empty strings' do
+    is_expected.to run.with_params([['a', ''], ['b', '2']]).and_return("b=2")
+  end
 end


### PR DESCRIPTION
There exists the possibility a parameter passed to build_dn could be an empty string which breaks the previous requirement on a string of length at least one, String[1]. Change to accept any length string but if the string happens to be empty, filter it out of the calculation.