### PR TITLE
install katello-selinux when SELinux is enabled

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,6 +65,12 @@ class katello (
     }
   }
 
+  if $facts['os']['selinux']['enabled'] {
+    package { 'katello-selinux':
+      ensure => installed,
+    }
+  }
+
   class { 'katello::application':
     rest_client_timeout => $rest_client_timeout,
     hosts_queue_workers => $hosts_queue_workers,


### PR DESCRIPTION
Similar to theforeman/puppet-foreman#79

katello-selinux allows foreman_rails_t to connect to candlepin_activemq_port_t