### PR TITLE
Remove invalid default for $katello::repo::repo_version

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # @summary Manage the Katello repository
 #
 # @param repo_version
-#   The repository version to use. Either latest or a version like 3.14.
+#   The repository version to use
 # @param dist
 #   The distribution to use
 # @param gpgcheck
@@ -9,7 +9,7 @@
 # @param gpgkey
 #   The location of the GPG key
 class katello::repo (
-  String $repo_version = latest,
+  Variant[Pattern[/^\d\.\d+$/], Enum['nightly']] $repo_version,
   String $dist = "el${facts['os']['release']['major']}",
   Boolean $gpgcheck = false,
   String $gpgkey = 'absent',

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -63,7 +63,13 @@ describe 'katello::application' do
       end
 
       context 'with repo present' do
-        let(:pre_condition) { 'include katello::repo' }
+        let(:pre_condition) do
+          <<~PUPPET
+            class { 'katello::repo':
+              repo_version => 'nightly',
+            }
+          PUPPET
+        end
 
         it { is_expected.to compile.with_all_deps }
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
 describe 'katello::repo' do
-  context 'with default parameters' do
-    let(:facts) { { os: { release: { major: '8' } } } }
+  let(:facts) { { os: { release: { major: '8' } } } }
 
+  context 'with default parameters' do
     it do
       is_expected.to contain_yumrepo('katello')
         .with_descr('katello latest')
@@ -17,8 +17,6 @@ describe 'katello::repo' do
   end
 
   context 'with manage_repo => true' do
-    let(:facts) { { os: { release: { major: '8' } } } }
-
     let :params do
       {
         'repo_version' => '3.14',
@@ -38,8 +36,6 @@ describe 'katello::repo' do
     end
   end
   context 'with manage_repo => true on EL8 with modular metadata' do
-    let(:facts) { { os: { release: { major: '8' } } } }
-
     let :params do
       {
         'repo_version' => 'nightly',

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -4,10 +4,20 @@ describe 'katello::repo' do
   let(:facts) { { os: { release: { major: '8' } } } }
 
   context 'with default parameters' do
+    it { is_expected.to compile.and_raise_error(//) }
+  end
+
+  context 'with nightly repo' do
+    let :params do
+      {
+        'repo_version' => 'nightly',
+      }
+    end
+
     it do
       is_expected.to contain_yumrepo('katello')
-        .with_descr('katello latest')
-        .with_baseurl("https://yum.theforeman.org/katello/latest/katello/el8/\$basearch/")
+        .with_descr('katello nightly')
+        .with_baseurl("https://yum.theforeman.org/katello/nightly/katello/el8/\$basearch/")
         .with_gpgkey('absent')
         .with_gpgcheck(false)
         .with_enabled(true)


### PR DESCRIPTION
The version `latest` doesn't exist. This drops the default and adds stricter validation. Because other values this can be considered a bugfix, even though technically it's changing the API.

Fixes #472