### PR TITLE
Only install dnf module on EL8

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -25,12 +25,14 @@ class katello::repo (
 
   Anchor <| title == 'foreman::repo' |> -> Yumrepo['katello']
 
-  package { 'katello-dnf-module':
-    ensure      => $dist,
-    name        => 'katello',
-    enable_only => true,
-    provider    => 'dnfmodule',
-    require     => Yumrepo['katello'],
-    before      => Anchor['katello::repo'],
+  if $facts['os']['release']['major'] == '8' {
+    package { 'katello-dnf-module':
+      ensure      => $dist,
+      name        => 'katello',
+      enable_only => true,
+      provider    => 'dnfmodule',
+      require     => Yumrepo['katello'],
+      before      => Anchor['katello::repo'],
+    }
   }
 }


### PR DESCRIPTION
We don't intend to use modularity on the initial release, so scope this to only EL8.