### PR TITLE
Add facts_match_regex parameter in katello class

### DIFF
--- a/manifests/candlepin.pp
+++ b/manifests/candlepin.pp
@@ -24,6 +24,8 @@
 #   Artemis. It should still be signed by the correct Certificate Authority.
 # @param loggers
 #   Configure the Candlepin loggers
+# @param facts_match_regex
+#   Configure the Candlepin facts_match_regex
 class katello::candlepin (
   Stdlib::Host $db_host = 'localhost',
   Optional[Stdlib::Port] $db_port = undef,
@@ -36,6 +38,7 @@ class katello::candlepin (
   Boolean $manage_db = true,
   Variant[Undef, Deferred, String[1]] $artemis_client_dn = undef,
   Hash[String[1], Candlepin::LogLevel] $loggers = {},
+  Optional[String[1]] $facts_match_regex = undef,
 ) {
   include certs
   include katello::params
@@ -73,6 +76,7 @@ class katello::candlepin (
     db_ssl_ca                    => $db_ssl_ca,
     manage_db                    => $manage_db,
     loggers                      => $loggers,
+    facts_match_regex            => $facts_match_regex,
     subscribe                    => Class['certs', 'certs::candlepin'],
   } ->
   anchor { 'katello::candlepin': } # lint:ignore:anchor_resource

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@
 #
 # $candlepin_loggers:: Configure the Candlepin loggers
 #
+# $candlepin_facts_match_regex:: Configure the Candlepin facts_match_regex
+#
 # $rest_client_timeout:: Timeout for Katello rest API
 #
 # $hosts_queue_workers::   Configures the number of workers handling the hosts_queue queue.
@@ -38,9 +40,7 @@
 class katello (
   Optional[String] $candlepin_oauth_key = undef,
   Optional[String] $candlepin_oauth_secret = undef,
-
   Integer[0] $rest_client_timeout = 3600,
-
   String $candlepin_db_host = 'localhost',
   Optional[Stdlib::Port] $candlepin_db_port = undef,
   String $candlepin_db_name = 'candlepin',
@@ -51,6 +51,7 @@ class katello (
   Optional[Stdlib::Absolutepath] $candlepin_db_ssl_ca = undef,
   Boolean $candlepin_manage_db = true,
   Hash[String[1], Candlepin::LogLevel] $candlepin_loggers = {},
+  Optional[String[1]] $candlepin_facts_match_regex = undef,
 
   Integer[0] $hosts_queue_workers = 1,
 ) {
@@ -82,5 +83,6 @@ class katello (
     manage_db         => $candlepin_manage_db,
     artemis_client_dn => $katello::application::artemis_client_dn,
     loggers           => $candlepin_loggers,
+    facts_match_regex => $candlepin_facts_match_regex,
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -10,6 +10,16 @@ describe 'katello' do
       it { is_expected.to contain_class('katello::application') }
       it { is_expected.to contain_package('rubygem-katello').that_requires('Class[candlepin]') }
       it { is_expected.to contain_package('katello') }
+
+      context 'with facts_match_regex' do
+        let(:params) { { candlepin_facts_match_regex: 'test_match_regex' } }
+
+        it { is_expected.to compile.with_all_deps }
+
+        it 'should pass the facts_match_regex parameter to katello::candlepin' do
+          is_expected.to contain_class('katello::candlepin').with_facts_match_regex('test_match_regex')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
For reference: https://github.com/theforeman/puppet-candlepin/pull/262#pullrequestreview-2085605414

This PR adds `facts_match_regex` parameter support to `katello::candlepin`. It enables filtering consumer facts via regex patterns, enhancing configuration flexibility and control.

### Changes Made

- Introduced `facts_match_regex` parameter in `katello::candlepin`.
- Updated `katello` class to pass `facts_match_regex` to `katello::candlepin`.
- Added unit tests to validate parameter functionality.