### PR TITLE
Fixes #37680 - Stop installing postgresql_evr extension

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -27,7 +27,6 @@ class katello::application (
   $candlepin_ca_cert = $certs::ca_cert
   $candlepin_events_ssl_cert = $certs::foreman::client_cert
   $candlepin_events_ssl_key = $certs::foreman::client_key
-  $postgresql_evr_package = $katello::params::postgresql_evr_package
   $manage_db = $foreman::db_manage
 
   # Used in Candlepin
@@ -39,12 +38,6 @@ class katello::application (
     package     => $foreman::plugin_prefix.regsubst(/foreman_/, 'katello'),
     config      => template('katello/katello.yaml.erb'),
     config_file => "${foreman::plugin_config_dir}/katello.yaml",
-  }
-
-  if $manage_db {
-    package { $postgresql_evr_package:
-      ensure => installed,
-    }
   }
 
   # required by configuration in katello-apache-ssl.conf

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -4,5 +4,4 @@ class katello::globals {
   # OAUTH settings
   $candlepin_oauth_key = 'katello'
   $candlepin_oauth_secret = extlib::cache_data('foreman_cache_data', 'candlepin_oauth_secret', extlib::random_password(32))
-  $postgresql_evr_package = 'postgresql-evr'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,8 +16,6 @@
 #   The oauth key for Candlepin
 # @param candlepin_oauth_secret
 #   The oauth secret for Candlepin
-# @param postgresql_evr_package
-#   The contextual package name for the PostgreSQL EVR extension
 class katello::params (
   String[1] $candlepin_oauth_key = $katello::globals::candlepin_oauth_key,
   String[1] $candlepin_oauth_secret = $katello::globals::candlepin_oauth_secret,
@@ -25,6 +23,5 @@ class katello::params (
   Stdlib::Port $candlepin_port = 23443,
   Stdlib::HTTPSUrl $candlepin_url = "https://${candlepin_host}:${candlepin_port}/candlepin",
   String[1] $candlepin_client_keypair_group = 'foreman',
-  String[1] $postgresql_evr_package = $katello::globals::postgresql_evr_package,
   String[0] $meta_package = 'katello',
 ) inherits katello::globals {}

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -19,7 +19,6 @@ describe 'katello::application' do
 
         it { is_expected.to create_package('rubygem-katello') }
         it { is_expected.not_to create_package('rubygem-katello').that_requires('Anchor[katello::candlepin]') }
-        it { is_expected.to create_package('postgresql-evr') }
 
         it do
           is_expected.to contain_service('httpd')

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -16,15 +16,6 @@ file { '/etc/foreman':
   ensure => directory,
 }
 
-# Necessary for PostgreSQL EVR extension
-yumrepo { 'pulpcore':
-  baseurl  => "http://yum.theforeman.org/pulpcore/3.39/el\$releasever/\$basearch/",
-  descr    => 'Pulpcore',
-  enabled  => true,
-  gpgcheck => true,
-  gpgkey   => 'https://yum.theforeman.org/pulpcore/3.39/GPG-RPM-KEY-pulpcore',
-}
-
 package { 'glibc-langpack-en':
   ensure => installed,
 }


### PR DESCRIPTION
Ref: https://github.com/Katello/katello/pull/11087 which removes postgresql_evr from katello and adds the migration to create the type and trigger needed.

Goal of this PR is to uninstall postgresql_evr on existing setups and to stop installing it on new ones. 