### PR TITLE
Fixes #37687 - Uninstall rubygem-anemone on boxes

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -47,6 +47,10 @@ class katello::application (
     }
   }
 
+  package { 'rubygem-anemone':
+    ensure => absent,
+  }
+
   # required by configuration in katello-apache-ssl.conf
   include apache::mod::setenvif
 


### PR DESCRIPTION
Ensure rubygem-anemone is removed following removal of the dependency from katello.