### PR TITLE
Correct minimum version of katello/candlepin

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "katello/candlepin",
-      "version_requirement": ">= 13.2.0 < 17.0.0"
+      "version_requirement": ">= 16.1.0 < 17.0.0"
     },
     {
       "name": "katello/certs",


### PR DESCRIPTION
e057cf36147ece1fb9827e9122f98e9ab1ce0ba7 started using a parameter that was introduced in 16.1.0.

Fixes: e057cf36147e ("Add facts_match_regex paramter in katello class")