### PR TITLE
Use the default CA certificate deployed into Foreman directory

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -24,7 +24,7 @@ class katello::application (
   $candlepin_url = $katello::params::candlepin_url
   $candlepin_oauth_key = $katello::params::candlepin_oauth_key
   $candlepin_oauth_secret = $katello::params::candlepin_oauth_secret
-  $candlepin_ca_cert = $certs::ca_cert
+  $candlepin_ca_cert = $certs::foreman::default_ca_cert
   $candlepin_events_ssl_cert = $certs::foreman::client_cert
   $candlepin_events_ssl_key = $certs::foreman::client_key
   $manage_db = $foreman::db_manage


### PR DESCRIPTION
Relies on using https://github.com/theforeman/puppet-certs/pull/489