### PR TITLE
Use Foreman CA certificate bundle instead of removed certs::ca_cert

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -24,7 +24,7 @@ class katello::application (
   $candlepin_url = $katello::params::candlepin_url
   $candlepin_oauth_key = $katello::params::candlepin_oauth_key
   $candlepin_oauth_secret = $katello::params::candlepin_oauth_secret
-  $candlepin_ca_cert = $certs::ca_cert
+  $candlepin_ca_cert = $certs::foreman::ssl_ca_cert
   $candlepin_events_ssl_cert = $certs::foreman::client_cert
   $candlepin_events_ssl_key = $certs::foreman::client_key
   $manage_db = $foreman::db_manage

--- a/spec/classes/application_spec.rb
+++ b/spec/classes/application_spec.rb
@@ -48,11 +48,11 @@ describe 'katello::application' do
             '    :url: https://localhost:23443/candlepin',
             '    :oauth_key: "katello"',
             '    :oauth_secret: "candlepin-secret"',
-            '    :ca_cert_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '    :ca_cert_file: /etc/foreman/proxy_ca.pem',
             '  :candlepin_events:',
             '    :ssl_cert_file: /etc/foreman/client_cert.pem',
             '    :ssl_key_file: /etc/foreman/client_key.pem',
-            '    :ssl_ca_file: /etc/pki/katello/certs/katello-default-ca.crt',
+            '    :ssl_ca_file: /etc/foreman/proxy_ca.pem',
           ]
         end
 


### PR DESCRIPTION
Long term solution is to remove this configuration and rely on the application to use the Foreman settings (https://github.com/Katello/katello/pull/11327). This is needed to fill the gap in the short term.